### PR TITLE
Fix: Poll creation now only shows SABC tournaments, not holidays

### DIFF
--- a/app_routes.py
+++ b/app_routes.py
@@ -1544,6 +1544,7 @@ async def create_poll_form(request: Request, event_id: int = Query(None)):
                 LEFT JOIN polls p ON e.id = p.event_id
                 WHERE p.id IS NULL
                 AND e.date >= date('now')
+                AND e.event_type = 'sabc_tournament'
                 ORDER BY e.date ASC
             """)
 


### PR DESCRIPTION
## Summary
- Fixed poll creation to only display SABC tournaments in event selection
- Added `event_type = 'sabc_tournament'` filter to exclude holidays and other event types
- Resolves issue where federal holidays were incorrectly appearing in tournament poll creation

## Changes Made
- Modified poll creation query in `app_routes.py:1547` to filter by event_type
- Only shows events where `event_type = 'sabc_tournament'`
- Excludes federal holidays, other tournaments, and club events from poll selection

## Test Plan
- [x] Verified query returns only SABC tournaments (no holidays)
- [x] Confirmed application still loads correctly
- [x] Ran format-code and check-code - all checks pass
- [x] Database query tested with sample data

## Before/After
**Before**: Poll creation showed 396 holidays mixed with 47 tournaments
**After**: Poll creation shows only the 47 SABC tournaments

Fixes #145

🤖 Generated with [Claude Code](https://claude.ai/code)