### PR TITLE
Fix: Admin tournaments page now shows correct federal holiday count

### DIFF
--- a/templates/admin/events.html
+++ b/templates/admin/events.html
@@ -124,7 +124,7 @@
                 <li class="nav-item" role="presentation">
                     <button class="nav-link text-light" id="holidays-tab" data-bs-toggle="tab" data-bs-target="#holidays-events" type="button" role="tab" aria-controls="holidays-events" aria-selected="false">
                         <i class="bi bi-calendar-heart me-2"></i>Federal Holidays
-                        <span class="badge bg-info ms-2" id="holidays-count">{{ events|selectattr('event_type', 'equalto', 'federal_holiday')|list|length }}</span>
+                        <span class="badge bg-info ms-2" id="holidays-count">{{ events|selectattr('event_type', 'equalto', 'holiday')|list|length }}</span>
                     </button>
                 </li>
                 <li class="nav-item" role="presentation">
@@ -228,7 +228,7 @@
                         </div>
                     </div>
                     
-                    {% set sabc_events = events|selectattr('event_type', 'equalto', 'federal_holiday')|list %}
+                    {% set sabc_events = events|selectattr('event_type', 'equalto', 'holiday')|list %}
                     {% include 'admin/events_table.html' with context %}
                 </div>
 

--- a/templates/admin/events_table.html
+++ b/templates/admin/events_table.html
@@ -11,7 +11,7 @@
                 <th width="8%">Fee</th>
                 <th width="12%">Poll Status</th>
                 <th width="12%">Tournament</th>
-                {% elif sabc_events|selectattr('event_type', 'equalto', 'federal_holiday')|list %}
+                {% elif sabc_events|selectattr('event_type', 'equalto', 'holiday')|list %}
                 <th width="20%">Holiday</th>
                 <th width="20%">Details</th>
                 {% else %}
@@ -82,7 +82,7 @@
                     {% endif %}
                 </td>
                 
-                {% elif event.event_type == 'federal_holiday' %}
+                {% elif event.event_type == 'holiday' %}
                 <td>
                     <span class="badge bg-info">
                         <i class="bi bi-calendar-heart me-1"></i>{{ event.holiday_name or event.name }}

--- a/templates/admin/past_events_table.html
+++ b/templates/admin/past_events_table.html
@@ -22,7 +22,7 @@
                 <td>
                     {% if event.event_type == 'sabc_tournament' %}
                         <span class="badge bg-primary"><i class="bi bi-trophy"></i></span>
-                    {% elif event.event_type == 'federal_holiday' %}
+                    {% elif event.event_type == 'holiday' %}
                         <span class="badge bg-info"><i class="bi bi-calendar-heart"></i></span>
                     {% elif event.event_type == 'other_tournament' %}
                         <span class="badge bg-warning"><i class="bi bi-calendar"></i></span>
@@ -47,7 +47,7 @@
                         {% if event.start_time %}
                         <br><small class="text-muted"><i class="bi bi-clock"></i> {{ event.start_time }} - {{ event.weigh_in_time or '15:00' }}</small>
                         {% endif %}
-                    {% elif event.event_type == 'federal_holiday' %}
+                    {% elif event.event_type == 'holiday' %}
                         <br><small class="text-info">{{ event.holiday_name }}</small>
                     {% endif %}
                 </td>


### PR DESCRIPTION
## Summary
- Fixed admin tournaments page to display correct federal holiday count (396 instead of 0)
- Corrected template filters to match actual database schema where holidays are stored as `event_type = 'holiday'`
- Ensures consistency between admin tournaments page and calendar page display

## Root Cause
The admin tournaments page templates were filtering for `event_type = 'federal_holiday'` but the database actually stores holidays with `event_type = 'holiday'`. This caused the template filter to return 0 matches instead of the correct 396 holidays.

## Changes Made
- **templates/admin/events.html**: Updated holiday count badge filter and tab content filter
- **templates/admin/events_table.html**: Fixed conditional logic for holiday display
- **templates/admin/past_events_table.html**: Updated holiday event type checks

## Test Plan
- [x] Verified database has 396 records with `event_type = 'holiday'`
- [x] Confirmed calendar page correctly uses `'holiday'` filter
- [x] Updated templates now use consistent `'holiday'` event type
- [x] Application loads correctly after changes
- [x] All code quality checks pass

## Before/After
**Before**: Admin tournaments page showed "0 federal holidays"
**After**: Admin tournaments page shows "396 federal holidays" (matching calendar page)

## Data Consistency Note
The database schema defines `event_type` with options including `'federal_holiday'`, but actual data uses `'holiday'`. This fix aligns the templates with the data reality while maintaining consistency with the calendar page display.

Fixes #144

🤖 Generated with [Claude Code](https://claude.ai/code)