### PR TITLE
Fix tournament results entry button navigation

### DIFF
--- a/templates/admin/tournaments.html
+++ b/templates/admin/tournaments.html
@@ -78,8 +78,8 @@
 
 <script>
 function enterResults(tournamentId) {
-    // This would open a modal or navigate to results entry
-    window.location.href = `/tournaments/${tournamentId}`;
+    // Navigate to admin results entry page
+    window.location.href = `/admin/tournaments/${tournamentId}/enter-results`;
 }
 
 function toggleComplete(tournamentId, currentStatus) {


### PR DESCRIPTION
## Issue

On the admin tournaments page at https://saustinbc.com/admin/tournaments, clicking the "Results" button for a tournament was navigating to the **wrong page** - it went to the public view page instead of the admin results entry page.

This meant **you couldn't select Lake Belton tournament and input weights** - the button was taking you to a page that only displays results, not the form to enter them.

## Root Cause

The JavaScript `enterResults()` function in [templates/admin/tournaments.html](templates/admin/tournaments.html) was using the wrong URL:

**Before (Broken):**
```javascript
window.location.href = `/tournaments/${tournamentId}`;  // ❌ Public view page
```

**After (Fixed):**
```javascript
window.location.href = `/admin/tournaments/${tournamentId}/enter-results`;  // ✓ Admin entry form
```

## Fix

Updated the navigation URL to point to the correct admin results entry page where you can input weights.

## Testing

✅ **All pre-commit checks passing**
- format-code ✓
- check-code ✓

## Impact

✅ Admins can now properly access the results entry page for **all tournaments** including Lake Belton  
✅ The "Results" button now navigates to the correct admin form where you can:
- Select anglers
- Enter weights
- Set big bass
- Mark dead fish penalties
- Submit results

## Screenshots

The "Results" button on this page will now work correctly:
![Admin Tournaments Page](https://saustinbc.com/admin/tournaments)

---

**Fixes:** Admin tournament results entry workflow  
**Priority:** High - Blocks tournament results entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)