### PR TITLE
Fix poll button logic for closed polls and add deep linking

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -512,16 +512,16 @@
                         {% endif %}
                         {% endif %}
 
-                        {% if tournament.poll_id and not tournament.user_has_voted %}
+                        {% if tournament.poll_id and tournament.poll_is_open and not tournament.user_has_voted %}
                         <div class="d-flex justify-content-end">
-                            <a href="/polls" class="btn btn-success btn-lg">
+                            <a href="/polls?tab=tournament#poll-{{ tournament.poll_id }}" class="btn btn-success btn-lg">
                                 <i class="bi bi-hand-index me-2"></i>Vote on Location
                             </a>
                         </div>
-                        {% elif tournament.poll_id and tournament.user_has_voted %}
+                        {% elif tournament.poll_id and (not tournament.poll_is_open or tournament.user_has_voted) %}
                         <div class="d-flex justify-content-end">
-                            <a href="/polls" class="btn btn-outline-info">
-                                <i class="bi bi-bar-chart-fill me-2"></i>View Full Results
+                            <a href="/polls?tab=tournament#poll-{{ tournament.poll_id }}" class="btn btn-outline-info">
+                                <i class="bi bi-bar-chart-fill me-2"></i>View Poll Results
                             </a>
                         </div>
                         {% endif %}


### PR DESCRIPTION
Fixes #204

## Problem
On the home page, upcoming tournaments with polls showed incorrect button behavior:
1. **Closed polls showed wrong button**: Displayed "Vote on Location" even when poll was closed
2. **Wrong button text after voting**: Showed "View Full Results" instead of "View Poll Results"
3. **No deep linking**: Both buttons went to `/polls` page instead of the specific poll

## Solution
Updated button logic in `templates/index.html` to:
- Check `poll_is_open` status to determine which button to show
- Show "Vote on Location" ONLY if: poll exists AND poll is open AND user hasn't voted
- Show "View Poll Results" if: poll exists AND (poll is closed OR user has voted)
- Added deep linking to specific polls: `/polls?tab=tournament#poll-{poll_id}`
- Standardized button text to "View Poll Results"

## Testing
✅ All 883 tests pass
✅ `format-code` passes
✅ `check-code` passes (MyPy + Ruff)
✅ `run-tests` passes

## Changes
- Updated poll button conditional logic to check `poll_is_open`
- Changed "View Full Results" to "View Poll Results" for consistency
- Added poll_id to button href for deep linking to specific polls

🤖 Generated with [Claude Code](https://claude.com/claude-code)