### PR TITLE
Phase 2: Consolidate poll result visualization

### DIFF
--- a/static/home-polls.js
+++ b/static/home-polls.js
@@ -5,8 +5,8 @@
  * on the home page, including lakes, ramps, and tournament times voting results.
  */
 
-// Global state for lakes data
-let lakesDataGlobal = [];
+// Global state for home page poll renderer
+let homeResultsRenderer;
 
 /**
  * Initialize home page poll visualization
@@ -14,222 +14,29 @@ let lakesDataGlobal = [];
  * @param {Array} config.lakesData - Array of lakes with ramps data
  */
 function initializeHomePolls(config) {
-    lakesDataGlobal = config.lakesData || [];
+    const lakesData = config.lakesData || [];
 
-    // Render poll results for all tournament containers
-    renderAllPollResults();
+    // Initialize poll results renderer using shared PollResultsRenderer class
+    homeResultsRenderer = new PollResultsRenderer({
+        lakesData: lakesData,
+        containerSelector: '.tournament-results-container-home',
+        idAttribute: 'tournamentId'
+    });
+    homeResultsRenderer.renderAll();
 
     // Handle tab switching for pagination
     handleTabSwitching();
 }
 
-// Note: formatTime12Hour, getLakeName, and getRampName are defined in utils.js
-// Local wrapper functions that use the global lakesDataGlobal variable
-
 /**
- * Get lake name by ID using global lakes data
- * @param {number} lakeId - Lake ID
- * @returns {string} Lake name or fallback
- */
-function getLakeNameHome(lakeId) {
-    return getLakeName(lakesDataGlobal, lakeId);
-}
-
-/**
- * Get ramp name by ID using global lakes data
- * @param {number} rampId - Ramp ID
- * @returns {string} Ramp name or fallback
- */
-function getRampNameHome(rampId) {
-    return getRampName(lakesDataGlobal, rampId);
-}
-
-/**
- * Draw lakes voting chart for a tournament
- * @param {HTMLElement} container - Container element
- * @param {Object} resultsData - Poll results data
- * @param {number} tournamentId - Tournament ID
- */
-function drawLakesChartHome(container, resultsData, tournamentId) {
-    const chartContainer = container.querySelector(`#lakesChart-${tournamentId}`);
-    if (!chartContainer) return;
-
-    const data = resultsData.lakes;
-    if (!data || data.length === 0) {
-        chartContainer.innerHTML = '<div class="text-secondary text-center py-4"><i class="bi bi-inbox me-2"></i>No votes yet</div>';
-        return;
-    }
-
-    const maxVotes = Math.max(...data.map(d => d.votes));
-    chartContainer.innerHTML = data.map(lake => {
-        const percentage = (lake.votes / maxVotes) * 100;
-        return `
-            <div class="lake-card mb-2" data-lake-id="${lake.id}" style="cursor: pointer;" onclick="selectLakeHome(${lake.id}, ${tournamentId})">
-                <div class="d-flex justify-content-between align-items-center mb-1">
-                    <span class="fw-semibold">${escapeHtml(lake.name)}</span>
-                    <span class="badge bg-primary">${lake.votes}</span>
-                </div>
-                <div class="progress" style="height: 25px;">
-                    <div class="progress-bar lake-bar bg-success" role="progressbar" style="width: ${percentage}%"></div>
-                </div>
-            </div>
-        `;
-    }).join('');
-}
-
-/**
- * Draw ramps voting chart for a selected lake
- * @param {number} lakeId - Lake ID
- * @param {number} tournamentId - Tournament ID
- */
-function drawRampsChartHome(lakeId, tournamentId) {
-    const container = document.querySelector(`#rampsChart-${tournamentId}`);
-    if (!container) return;
-
-    const resultsData = window[`pollResultsData_${tournamentId}`];
-    if (!resultsData || !resultsData.ramps) {
-        container.innerHTML = '<div class="text-secondary text-center py-4"><i class="bi bi-arrow-up me-2"></i>Select a lake above to see ramps</div>';
-        return;
-    }
-
-    const ramps = resultsData.ramps.filter(r => r.lake_id == lakeId);
-    if (ramps.length === 0) {
-        container.innerHTML = '<div class="text-secondary text-center py-4"><i class="bi bi-inbox me-2"></i>No votes for ramps at this lake</div>';
-        return;
-    }
-
-    const maxVotes = Math.max(...ramps.map(r => r.votes));
-    container.innerHTML = ramps.map(ramp => {
-        const percentage = (ramp.votes / maxVotes) * 100;
-        return `
-            <div class="mb-2">
-                <div class="d-flex justify-content-between align-items-center mb-1">
-                    <span class="fw-semibold">${escapeHtml(ramp.name)}</span>
-                    <span class="badge bg-primary">${ramp.votes}</span>
-                </div>
-                <div class="progress" style="height: 25px;">
-                    <div class="progress-bar bg-info" role="progressbar" style="width: ${percentage}%"></div>
-                </div>
-            </div>
-        `;
-    }).join('');
-}
-
-/**
- * Handle lake selection for a tournament
+ * Handle lake selection for a tournament (wrapper for backward compatibility)
  * @param {number} lakeId - Lake ID
  * @param {number} tournamentId - Tournament ID
  */
 function selectLakeHome(lakeId, tournamentId) {
-    const container = document.querySelector(`[data-tournament-id="${tournamentId}"]`);
-    if (!container) return;
-
-    // Remove selection from all lake cards
-    container.querySelectorAll('.lake-card').forEach(card => {
-        card.classList.remove('border', 'border-primary', 'border-2');
-        card.style.backgroundColor = '';
-    });
-
-    // Add selection to clicked lake card
-    const selectedCard = container.querySelector(`[data-lake-id="${lakeId}"]`);
-    if (selectedCard) {
-        selectedCard.classList.add('border', 'border-primary', 'border-2');
-        selectedCard.style.backgroundColor = 'rgba(13, 110, 253, 0.05)';
+    if (homeResultsRenderer) {
+        homeResultsRenderer.selectLake(tournamentId, lakeId);
     }
-
-    // Update selected lake label
-    const selectedLakeLabel = container.querySelector(`#selectedLake-${tournamentId}`);
-    if (selectedLakeLabel) {
-        selectedLakeLabel.textContent = getLakeNameHome(lakeId);
-    }
-
-    // Draw ramps chart for selected lake
-    drawRampsChartHome(lakeId, tournamentId);
-}
-
-/**
- * Render poll results for all tournament containers
- */
-function renderAllPollResults() {
-    const resultsContainers = document.querySelectorAll('.tournament-results-container-home');
-
-    resultsContainers.forEach(container => {
-        const tournamentId = container.dataset.tournamentId;
-        const optionElements = container.querySelectorAll('.poll-option-data');
-
-        const lakes = {};
-        const ramps = {};
-        const times = {};
-
-        // Aggregate votes from poll options
-        optionElements.forEach(el => {
-            const pollOptionData = el.dataset.optionData ? JSON.parse(el.dataset.optionData) : {};
-            const voteCount = parseInt(el.dataset.voteCount) || 0;
-
-            if (voteCount === 0) return;
-
-            const lakeId = pollOptionData.lake_id;
-            const rampId = pollOptionData.ramp_id;
-            const startTime = pollOptionData.start_time;
-            const endTime = pollOptionData.end_time;
-
-            // Aggregate lake votes
-            if (lakeId) {
-                if (!lakes[lakeId]) {
-                    lakes[lakeId] = { id: lakeId, name: getLakeNameHome(lakeId), votes: 0 };
-                }
-                lakes[lakeId].votes += voteCount;
-            }
-
-            // Aggregate ramp votes
-            if (rampId) {
-                if (!ramps[rampId]) {
-                    ramps[rampId] = { id: rampId, lake_id: lakeId, name: getRampNameHome(rampId), votes: 0 };
-                }
-                ramps[rampId].votes += voteCount;
-            }
-
-            // Aggregate time votes
-            if (startTime && endTime) {
-                const timeKey = `${startTime}-${endTime}`;
-                if (!times[timeKey]) {
-                    times[timeKey] = { start_time: startTime, weigh_in_time: endTime, votes: 0 };
-                }
-                times[timeKey].votes += voteCount;
-            }
-        });
-
-        // Sort by votes (descending)
-        const lakesArray = Object.values(lakes).sort((a, b) => b.votes - a.votes);
-        const rampsArray = Object.values(ramps).sort((a, b) => b.votes - a.votes);
-        const timesArray = Object.values(times).sort((a, b) => b.votes - a.votes);
-
-        // Store results data globally for this tournament
-        const resultsData = { lakes: lakesArray, ramps: rampsArray, times: timesArray };
-        window[`pollResultsData_${tournamentId}`] = resultsData;
-
-        // Render visualizations if there are votes
-        if (lakesArray.length > 0 || rampsArray.length > 0 || timesArray.length > 0) {
-            drawLakesChartHome(container, resultsData, tournamentId);
-
-            // Render times table
-            const timesTable = container.querySelector(`#timeTable-${tournamentId} tbody`);
-            if (timesTable && timesArray.length > 0) {
-                timesTable.innerHTML = timesArray.map(time => `
-                    <tr>
-                        <td class="small">${formatTime12Hour(time.start_time)}</td>
-                        <td class="small">${formatTime12Hour(time.weigh_in_time)}</td>
-                        <td class="small text-center"><span class="badge bg-primary">${time.votes}</span></td>
-                    </tr>
-                `).join('');
-            }
-
-            // Auto-select lake if there's only one option
-            if (lakesArray.length === 1 && rampsArray.length > 0) {
-                selectLakeHome(lakesArray[0].id, tournamentId);
-            }
-        }
-    });
 }
 
 /**

--- a/static/polls-page.js
+++ b/static/polls-page.js
@@ -5,6 +5,7 @@
 
 // Initialize delete confirmation manager
 let pollDeleteManager;
+let pollResultsRenderer;
 
 document.addEventListener('DOMContentLoaded', function() {
     console.log('[SABC] Polls page: DOMContentLoaded fired');
@@ -40,8 +41,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
     console.log('[SABC] Poll voting handler initialized successfully');
 
-    // Render tournament poll results
-    renderPollResults(lakesData);
+    // Initialize poll results renderer using shared PollResultsRenderer class
+    pollResultsRenderer = new PollResultsRenderer({
+        lakesData: lakesData,
+        containerSelector: '.tournament-results-container',
+        idAttribute: 'pollId'
+    });
+    pollResultsRenderer.renderAll();
 
     // Initialize delete confirmation manager
     pollDeleteManager = new DeleteConfirmationManager({
@@ -59,190 +65,9 @@ function deletePoll(pollId, pollTitle) {
     pollDeleteManager.confirm(pollId, pollTitle);
 }
 
-/**
- * Render tournament poll results visualization
- * @param {Array} lakesData - Array of lakes with ramps
- */
-function renderPollResults(lakesData) {
-    var containers = document.querySelectorAll('.tournament-results-container');
-
-    containers.forEach(function(container) {
-        var pollId = container.dataset.pollId;
-        var optionElements = container.querySelectorAll('.poll-option-data');
-
-        var lakes = {};
-        var ramps = {};
-        var times = {};
-
-        // Aggregate votes from poll options
-        optionElements.forEach(function(el) {
-            var optionData = {};
-            try {
-                optionData = el.dataset.optionData ? JSON.parse(el.dataset.optionData) : {};
-            } catch (e) {
-                console.error('[SABC] Error parsing option data:', e);
-            }
-            var voteCount = parseInt(el.dataset.voteCount) || 0;
-
-            if (voteCount === 0) return;
-
-            var lakeId = optionData.lake_id;
-            var rampId = optionData.ramp_id;
-            var startTime = optionData.start_time;
-            var endTime = optionData.end_time;
-
-            // Aggregate lake votes
-            if (lakeId) {
-                if (!lakes[lakeId]) {
-                    lakes[lakeId] = { id: lakeId, name: getLakeName(lakesData, lakeId), votes: 0 };
-                }
-                lakes[lakeId].votes += voteCount;
-            }
-
-            // Aggregate ramp votes
-            if (rampId) {
-                if (!ramps[rampId]) {
-                    ramps[rampId] = { id: rampId, lake_id: lakeId, name: getRampName(lakesData, rampId), votes: 0 };
-                }
-                ramps[rampId].votes += voteCount;
-            }
-
-            // Aggregate time votes
-            if (startTime && endTime) {
-                var timeKey = startTime + '-' + endTime;
-                if (!times[timeKey]) {
-                    times[timeKey] = { start_time: startTime, end_time: endTime, votes: 0 };
-                }
-                times[timeKey].votes += voteCount;
-            }
-        });
-
-        // Sort by votes (descending)
-        var lakesArray = Object.values(lakes).sort(function(a, b) { return b.votes - a.votes; });
-        var rampsArray = Object.values(ramps).sort(function(a, b) { return b.votes - a.votes; });
-        var timesArray = Object.values(times).sort(function(a, b) { return b.votes - a.votes; });
-
-        // Store results data globally for this poll
-        window['pollResultsData_' + pollId] = { lakes: lakesArray, ramps: rampsArray, times: timesArray };
-
-        // Render lakes chart
-        drawLakesChart(pollId, lakesArray);
-
-        // Render times table
-        drawTimesTable(pollId, timesArray);
-
-        // Auto-select lake with most votes
-        if (lakesArray.length > 0 && rampsArray.length > 0) {
-            selectLakePoll(pollId, lakesArray[0].id);
-        }
-    });
-}
-
-// Note: getLakeName, getRampName, and formatTime12Hour are defined in utils.js
-
-function drawLakesChart(pollId, lakesArray) {
-    var chartContainer = document.getElementById('lakesChart-' + pollId);
-    if (!chartContainer) return;
-
-    if (!lakesArray || lakesArray.length === 0) {
-        chartContainer.innerHTML = '<div class="text-secondary text-center py-4"><i class="bi bi-inbox me-2"></i>No votes yet</div>';
-        return;
+// Expose selectLakePoll to global scope for backward compatibility
+window.selectLakePoll = function(pollId, lakeId) {
+    if (pollResultsRenderer) {
+        pollResultsRenderer.selectLake(pollId, lakeId);
     }
-
-    var maxVotes = Math.max.apply(null, lakesArray.map(function(d) { return d.votes; }));
-    chartContainer.innerHTML = lakesArray.map(function(lake) {
-        var percentage = (lake.votes / maxVotes) * 100;
-        return '<div class="lake-card mb-2" data-lake-id="' + lake.id + '" style="cursor: pointer;" onclick="selectLakePoll(' + pollId + ', ' + lake.id + ')">' +
-            '<div class="d-flex justify-content-between align-items-center mb-1">' +
-                '<span class="fw-semibold">' + escapeHtml(lake.name) + '</span>' +
-                '<span class="badge bg-primary">' + lake.votes + '</span>' +
-            '</div>' +
-            '<div class="progress" style="height: 25px;">' +
-                '<div class="progress-bar lake-bar bg-success" role="progressbar" style="width: ' + percentage + '%"></div>' +
-            '</div>' +
-        '</div>';
-    }).join('');
-}
-
-function drawRampsChart(pollId, lakeId) {
-    var container = document.getElementById('rampsChart-' + pollId);
-    if (!container) return;
-
-    var resultsData = window['pollResultsData_' + pollId];
-    if (!resultsData || !resultsData.ramps) {
-        container.innerHTML = '<div class="text-secondary text-center py-4"><i class="bi bi-arrow-up me-2"></i>Select a lake above to see ramps</div>';
-        return;
-    }
-
-    var ramps = resultsData.ramps.filter(function(r) { return r.lake_id == lakeId; });
-    if (ramps.length === 0) {
-        container.innerHTML = '<div class="text-secondary text-center py-4"><i class="bi bi-inbox me-2"></i>No votes for ramps at this lake</div>';
-        return;
-    }
-
-    var maxVotes = Math.max.apply(null, ramps.map(function(r) { return r.votes; }));
-    container.innerHTML = ramps.map(function(ramp) {
-        var percentage = (ramp.votes / maxVotes) * 100;
-        return '<div class="mb-2">' +
-            '<div class="d-flex justify-content-between align-items-center mb-1">' +
-                '<span class="fw-semibold">' + escapeHtml(ramp.name) + '</span>' +
-                '<span class="badge bg-primary">' + ramp.votes + '</span>' +
-            '</div>' +
-            '<div class="progress" style="height: 25px;">' +
-                '<div class="progress-bar bg-info" role="progressbar" style="width: ' + percentage + '%"></div>' +
-            '</div>' +
-        '</div>';
-    }).join('');
-}
-
-function drawTimesTable(pollId, timesArray) {
-    var tableBody = document.querySelector('#timeTable-' + pollId + ' tbody');
-    if (!tableBody) return;
-
-    if (!timesArray || timesArray.length === 0) {
-        tableBody.innerHTML = '<tr><td colspan="3" class="text-secondary text-center py-3"><i class="bi bi-inbox me-2"></i>No votes</td></tr>';
-        return;
-    }
-
-    tableBody.innerHTML = timesArray.map(function(time) {
-        return '<tr>' +
-            '<td class="small">' + formatTime12Hour(time.start_time) + '</td>' +
-            '<td class="small">' + formatTime12Hour(time.end_time) + '</td>' +
-            '<td class="small text-center"><span class="badge bg-primary">' + time.votes + '</span></td>' +
-        '</tr>';
-    }).join('');
-}
-
-function selectLakePoll(pollId, lakeId) {
-    var container = document.querySelector('[data-poll-id="' + pollId + '"].tournament-results-container');
-    if (!container) return;
-
-    // Remove selection from all lake cards
-    container.querySelectorAll('.lake-card').forEach(function(card) {
-        card.classList.remove('border', 'border-primary', 'border-2');
-        card.style.backgroundColor = '';
-    });
-
-    // Add selection to clicked lake card
-    var selectedCard = container.querySelector('[data-lake-id="' + lakeId + '"]');
-    if (selectedCard) {
-        selectedCard.classList.add('border', 'border-primary', 'border-2');
-        selectedCard.style.backgroundColor = 'rgba(13, 110, 253, 0.05)';
-    }
-
-    // Update selected lake label
-    var selectedLakeLabel = document.getElementById('selectedLake-' + pollId);
-    if (selectedLakeLabel) {
-        var resultsData = window['pollResultsData_' + pollId];
-        if (resultsData && resultsData.lakes) {
-            var lake = resultsData.lakes.find(function(l) { return l.id == lakeId; });
-            if (lake) selectedLakeLabel.textContent = lake.name;
-        }
-    }
-
-    // Draw ramps chart for selected lake
-    drawRampsChart(pollId, lakeId);
-}
-
-// Expose selectLakePoll to global scope for onclick handlers
-window.selectLakePoll = selectLakePoll;
+};


### PR DESCRIPTION
## Summary
- Create reusable `PollResultsRenderer` class in utils.js
- Both polls-page.js and home-polls.js now use this shared class
- Eliminates ~420 lines of duplicated visualization code

## Changes
- `utils.js`: Add `PollResultsRenderer` class with vote aggregation, chart rendering, and selection handling
- `polls-page.js`: 272 → 73 lines (use shared renderer)
- `home-polls.js`: 292 → 72 lines (use shared renderer)

## Test plan
- [x] All 891 tests pass
- [x] Code quality checks pass (ruff + mypy)
- [x] Verify poll results display correctly on /polls page
- [x] Verify poll results display correctly on home page
- [x] Verify lake selection updates ramp chart correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)