### PR TITLE
Phase 3: Standardize delete confirmation usage

### DIFF
--- a/static/admin-lakes.js
+++ b/static/admin-lakes.js
@@ -3,9 +3,21 @@
  * Handles lake CRUD operations and delete confirmation
  */
 
-let deleteLakeId = null;
+// Initialize delete confirmation manager
+let lakeDeleteManager;
 
 document.addEventListener('DOMContentLoaded', function() {
+    // Initialize delete confirmation manager
+    lakeDeleteManager = new DeleteConfirmationManager({
+        modalId: 'deleteLakeModal',
+        itemNameElementId: 'delete-lake-name',
+        confirmInputId: 'delete-confirmation',
+        confirmButtonId: 'confirmDeleteLakeBtn',
+        deleteUrlTemplate: (id) => `/admin/lakes/${id}`,
+        onSuccess: () => location.reload(),
+        onError: (error) => showToast(`Error deleting lake: ${error}`, 'error')
+    });
+
     // Delete button event listeners
     document.querySelectorAll('.delete-btn').forEach(button => {
         button.addEventListener('click', function() {
@@ -31,37 +43,5 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function deleteLake(id, displayName) {
-    // Set the lake info in the modal
-    deleteLakeId = id;
-    document.getElementById('delete-lake-name').textContent = displayName;
-    document.getElementById('delete-confirmation').value = '';
-
-    // Show the modal
-    showModal('deleteLakeModal');
-}
-
-async function confirmDeleteLake() {
-    const confirmText = document.getElementById('delete-confirmation').value;
-
-    if (confirmText.trim() !== 'DELETE') {
-        showToast('Please type DELETE to confirm', 'warning');
-        return;
-    }
-
-    // Close the modal
-    hideModal('deleteLakeModal');
-
-    // Delete the lake using centralized deleteRequest
-    try {
-        const response = await deleteRequest(`/admin/lakes/${deleteLakeId}`);
-        const data = await response.json();
-
-        if (data.success) {
-            window.location.reload();
-        } else {
-            showToast(`Error deleting lake: ${data.error || 'Unknown error'}`, 'error');
-        }
-    } catch (error) {
-        showToast(`Error deleting lake: ${error.message}`, 'error');
-    }
+    lakeDeleteManager.confirm(id, displayName);
 }

--- a/static/admin-news.js
+++ b/static/admin-news.js
@@ -3,9 +3,21 @@
  * Handles news CRUD operations, edit modal, and delete confirmation
  */
 
-let deleteNewsId = null;
+// Initialize delete confirmation manager
+let newsDeleteManager;
 
 document.addEventListener('DOMContentLoaded', function() {
+    // Initialize delete confirmation manager
+    newsDeleteManager = new DeleteConfirmationManager({
+        modalId: 'deleteNewsModal',
+        itemNameElementId: 'delete-news-title',
+        confirmInputId: 'delete-confirmation',
+        confirmButtonId: 'confirmDeleteNewsBtn',
+        deleteUrlTemplate: (id) => `/admin/news/${id}`,
+        onSuccess: () => location.reload(),
+        onError: (error) => showToast(`Error deleting news: ${error}`, 'error')
+    });
+
     // Edit button event listeners
     document.querySelectorAll('.edit-btn').forEach(button => {
         button.addEventListener('click', function() {
@@ -79,37 +91,5 @@ function editNews(id, title, content, priority) {
 }
 
 function deleteNews(id, title) {
-    // Set the news info in the modal
-    deleteNewsId = id;
-    document.getElementById('delete-news-title').textContent = title;
-    document.getElementById('delete-confirmation').value = '';
-
-    // Show the modal
-    showModal('deleteNewsModal');
-}
-
-async function confirmDeleteNews() {
-    const confirmText = document.getElementById('delete-confirmation').value;
-
-    if (confirmText.trim() !== 'DELETE') {
-        showToast('Please type DELETE to confirm', 'warning');
-        return;
-    }
-
-    // Close the modal
-    hideModal('deleteNewsModal');
-
-    // Delete the news item using centralized deleteRequest
-    try {
-        const response = await deleteRequest(`/admin/news/${deleteNewsId}`);
-        const data = await response.json();
-
-        if (data.success) {
-            window.location.reload();
-        } else {
-            showToast(`Error deleting news: ${data.error || 'Unknown error'}`, 'error');
-        }
-    } catch (error) {
-        showToast(`Error deleting news: ${error.message}`, 'error');
-    }
+    newsDeleteManager.confirm(id, title);
 }


### PR DESCRIPTION
## Summary
- Convert admin-lakes.js and admin-news.js to use `DeleteConfirmationManager`
- Eliminates ~40 lines of duplicated delete confirmation logic
- Provides consistent UX across admin pages

## Files Changed
- `admin-lakes.js`: Now uses DeleteConfirmationManager (67 → 47 lines)
- `admin-news.js`: Now uses DeleteConfirmationManager (115 → 95 lines)

## Not Changed
- `admin-events.js`: Has more complex delete logic (two modals, dependencies warning)
- `tournament-results.js`: Uses simple `confirm()` dialogs, different pattern

## Test plan
- [x] All 891 tests pass
- [x] Code quality checks pass (ruff + mypy)
- [ ] Verify delete lake works on /admin/lakes
- [ ] Verify delete news works on /admin/news

🤖 Generated with [Claude Code](https://claude.com/claude-code)