### PR TITLE
Phase 5: Split admin-events.js into feature modules

### DIFF
--- a/static/admin-events-filters.js
+++ b/static/admin-events-filters.js
@@ -1,0 +1,172 @@
+/**
+ * Admin Events - Filtering Module
+ * Handles event list filtering, search, and tab badge updates
+ */
+
+/**
+ * Filter events in a specific tab
+ */
+function filterEvents(tabType) {
+    const searchInput = document.getElementById(`${tabType}-search`).value.toLowerCase();
+    const yearFilter = document.getElementById(`${tabType}-year-filter`)?.value;
+    const statusFilter = document.getElementById(`${tabType}-status-filter`)?.value;
+    const lakeFilter = document.getElementById(`${tabType}-lake-filter`)?.value.toLowerCase();
+    const typeFilter = document.getElementById(`${tabType}-type-filter`)?.value;
+    const resultsFilter = document.getElementById(`${tabType}-results-filter`)?.value;
+
+    // Determine the correct table selector based on tab type
+    let tableSelector;
+    if (tabType === 'past') {
+        tableSelector = '#past-events-tab table tbody tr';
+    } else if (tabType === 'past-tournaments') {
+        tableSelector = '#past-tournaments-events table tbody tr';
+    } else {
+        tableSelector = `#${tabType}-events table tbody tr`;
+    }
+
+    const rows = document.querySelectorAll(tableSelector);
+    let visibleCount = 0;
+
+    rows.forEach(row => {
+        // Skip rows with no data cells (e.g., empty state messages)
+        if (row.cells.length < 3) {
+            return;
+        }
+
+        let visible = true;
+
+        // Search filter
+        if (searchInput && !row.textContent.toLowerCase().includes(searchInput)) {
+            visible = false;
+        }
+
+        // Year filter
+        if (yearFilter && row.dataset.year !== yearFilter) {
+            visible = false;
+        }
+
+        // Status filter (for SABC tournaments)
+        if (statusFilter) {
+            if (statusFilter === 'has-poll' && !row.textContent.includes('\u{1F5F3}\u{FE0F}')) {
+                visible = false;
+            }
+            if (statusFilter === 'no-poll' && row.textContent.includes('\u{1F5F3}\u{FE0F}')) {
+                visible = false;
+            }
+            if (statusFilter === 'complete' && !row.textContent.includes('\u{2705}')) {
+                visible = false;
+            }
+            if (statusFilter === 'incomplete' && row.textContent.includes('\u{2705}')) {
+                visible = false;
+            }
+        }
+
+        // Lake filter
+        if (lakeFilter && row.dataset.lake && !row.dataset.lake.includes(lakeFilter)) {
+            visible = false;
+        }
+
+        // Type filter
+        if (typeFilter && row.dataset.eventType !== typeFilter) {
+            visible = false;
+        }
+
+        // Results filter
+        if (resultsFilter) {
+            const hasResults = row.dataset.hasResults === 'yes';
+            if (resultsFilter === 'has-results' && !hasResults) {
+                visible = false;
+            }
+            if (resultsFilter === 'no-results' && hasResults) {
+                visible = false;
+            }
+        }
+
+        row.style.display = visible ? '' : 'none';
+        if (visible) visibleCount++;
+    });
+
+    // Update empty state
+    updateEmptyState(tabType, visibleCount);
+}
+
+function clearFilters(tabType) {
+    // Clear all filter inputs for this tab
+    document.getElementById(`${tabType}-search`).value = '';
+
+    const yearFilter = document.getElementById(`${tabType}-year-filter`);
+    if (yearFilter) yearFilter.value = '';
+
+    const statusFilter = document.getElementById(`${tabType}-status-filter`);
+    if (statusFilter) statusFilter.value = '';
+
+    const lakeFilter = document.getElementById(`${tabType}-lake-filter`);
+    if (lakeFilter) lakeFilter.value = '';
+
+    const typeFilter = document.getElementById(`${tabType}-type-filter`);
+    if (typeFilter) typeFilter.value = '';
+
+    const resultsFilter = document.getElementById(`${tabType}-results-filter`);
+    if (resultsFilter) resultsFilter.value = '';
+
+    // Show all rows
+    let tableSelector;
+    if (tabType === 'past') {
+        tableSelector = '#past-events-tab table tbody tr';
+    } else if (tabType === 'past-tournaments') {
+        tableSelector = '#past-tournaments-events table tbody tr';
+    } else {
+        tableSelector = `#${tabType}-events table tbody tr`;
+    }
+
+    const rows = document.querySelectorAll(tableSelector);
+    let visibleCount = 0;
+
+    rows.forEach(row => {
+        if (row.cells.length > 2 && !row.textContent.includes('No events')) {
+            row.style.display = '';
+            visibleCount++;
+        }
+    });
+
+    updateEmptyState(tabType, visibleCount);
+}
+
+function updateEmptyState(tabType, visibleCount) {
+    // Update tab badges with filtered counts
+    let badgeId;
+    if (tabType === 'sabc') badgeId = 'sabc-count';
+    else if (tabType === 'holidays') badgeId = 'holidays-count';
+    else if (tabType === 'other') badgeId = 'other-count';
+    else if (tabType === 'past-tournaments') badgeId = 'past-tournaments-count';
+    else if (tabType === 'past') badgeId = 'past-count';
+
+    const tabBadge = document.getElementById(badgeId);
+
+    if (tabBadge && visibleCount !== undefined) {
+        // Store original count if not already stored
+        if (!tabBadge.dataset.originalCount) {
+            tabBadge.dataset.originalCount = tabBadge.textContent;
+        }
+
+        // Show filtered count if different from original
+        if (document.getElementById(`${tabType}-search`).value ||
+            document.getElementById(`${tabType}-year-filter`)?.value ||
+            document.getElementById(`${tabType}-status-filter`)?.value ||
+            document.getElementById(`${tabType}-lake-filter`)?.value ||
+            document.getElementById(`${tabType}-type-filter`)?.value ||
+            document.getElementById(`${tabType}-results-filter`)?.value) {
+            tabBadge.textContent = visibleCount;
+            tabBadge.classList.add('bg-warning');
+            tabBadge.classList.remove('bg-primary', 'bg-info', 'bg-secondary');
+        } else {
+            tabBadge.textContent = tabBadge.dataset.originalCount;
+            tabBadge.classList.remove('bg-warning');
+            // Restore original badge color based on tab
+            if (tabType === 'sabc') tabBadge.classList.add('bg-primary');
+            else if (tabType === 'holidays') tabBadge.classList.add('bg-info');
+            else if (tabType === 'other') tabBadge.classList.add('bg-warning');
+            else tabBadge.classList.add('bg-secondary');
+        }
+    }
+}

--- a/static/admin-events-forms.js
+++ b/static/admin-events-forms.js
@@ -1,0 +1,211 @@
+/**
+ * Admin Events - Form Configuration Module
+ * Handles event type-specific form field visibility and validation
+ */
+
+// Configuration-driven event form management
+// Base configurations for reuse
+const BASE_TOURNAMENT_CONFIG = {
+    clearFields: ['start_time', 'weigh_in_time'],
+    defaults: { start_time: '06:00', weigh_in_time: '15:00' },
+    requiredFields: []
+};
+
+const EMPTY_CONFIG = {
+    clearFields: [],
+    defaults: {},
+    requiredFields: []
+};
+
+const EVENT_FORM_CONFIG = {
+    sabc_tournament: {
+        ...BASE_TOURNAMENT_CONFIG,
+        visibleSections: ['sabc-tournament-fields'],
+        editSections: ['edit-tournament-fields', 'edit-sabc-fields'],
+        descriptionField: 'description'
+    },
+    holiday: {
+        ...EMPTY_CONFIG,
+        visibleSections: ['holiday-fields'],
+        editSections: ['edit-holiday-fields'],
+        descriptionField: null
+    },
+    other_tournament: {
+        ...EMPTY_CONFIG,
+        visibleSections: ['other-tournament-fields', 'other-tournament-description'],
+        editSections: ['edit-tournament-fields'],
+        descriptionField: 'other_description'
+    }
+};
+
+/**
+ * Utility: Hide all specified sections and disable their inputs
+ */
+function hideAllSections(sectionIds) {
+    sectionIds.forEach(id => {
+        const section = document.getElementById(id);
+        if (section) {
+            section.style.display = 'none';
+            // Disable all inputs in hidden sections so they don't submit
+            section.querySelectorAll('input, select, textarea').forEach(input => {
+                input.disabled = true;
+            });
+        }
+    });
+}
+
+/**
+ * Utility: Show specified sections and enable their inputs
+ */
+function showSections(sectionIds, displayType = 'flex') {
+    sectionIds.forEach(id => {
+        const section = document.getElementById(id);
+        if (section) {
+            section.style.display = displayType;
+            // Enable all inputs in visible sections
+            section.querySelectorAll('input, select, textarea').forEach(input => {
+                // Don't enable ramp selects - they're controlled by lake selection
+                if (!input.id.includes('ramp_name')) {
+                    input.disabled = false;
+                }
+            });
+        }
+    });
+}
+
+/**
+ * Utility: Clear specified form field values
+ */
+function clearFieldValues(fieldIds) {
+    fieldIds.forEach(id => {
+        const field = document.getElementById(id);
+        if (field) field.value = '';
+    });
+}
+
+/**
+ * Utility: Set default values for specified fields
+ */
+function setFieldDefaults(fieldValueMap) {
+    Object.entries(fieldValueMap).forEach(([fieldId, value]) => {
+        const field = document.getElementById(fieldId);
+        if (field) field.value = value;
+    });
+}
+
+/**
+ * Utility: Clear all 'required' attributes from form fields
+ */
+function clearAllRequirements() {
+    ['start_time', 'weigh_in_time', 'lake_name', 'ramp_name', 'other_description'].forEach(id => {
+        const field = document.getElementById(id);
+        if (field) field.removeAttribute('required');
+    });
+}
+
+/**
+ * Utility: Set 'required' attribute on specified fields
+ */
+function setFieldRequirements(requiredIds) {
+    requiredIds.forEach(id => {
+        const field = document.getElementById(id);
+        if (field) field.setAttribute('required', 'required');
+    });
+}
+
+/**
+ * Manage description fields based on event type
+ */
+function manageDescriptionFields(activeFieldId) {
+    const descriptionField = document.getElementById('description');
+    const otherDescriptionField = document.getElementById('other_description');
+
+    if (activeFieldId === 'other_description') {
+        // Hide general description, show other_description
+        if (descriptionField) {
+            descriptionField.closest('.col-md-3').style.display = 'none';
+            descriptionField.removeAttribute('required');
+        }
+        if (otherDescriptionField) {
+            otherDescriptionField.closest('.col-md-12').style.display = 'block';
+            otherDescriptionField.setAttribute('required', 'required');
+        }
+    } else if (activeFieldId === 'description') {
+        // Show general description, hide other_description
+        if (descriptionField) {
+            descriptionField.closest('.col-md-3').style.display = 'block';
+        }
+        if (otherDescriptionField) {
+            otherDescriptionField.closest('.col-md-12').style.display = 'none';
+            otherDescriptionField.removeAttribute('required');
+        }
+    } else {
+        // No description field active
+        if (descriptionField) {
+            descriptionField.closest('.col-md-3').style.display = 'block';
+        }
+        if (otherDescriptionField) {
+            otherDescriptionField.closest('.col-md-12').style.display = 'none';
+            otherDescriptionField.removeAttribute('required');
+        }
+    }
+}
+
+/**
+ * Get selected event type (create or edit mode)
+ */
+function getSelectedEventType(isEdit = false) {
+    const selectId = isEdit ? 'edit_event_type' : 'event_type';
+    return document.getElementById(selectId)?.value;
+}
+
+/**
+ * Toggle visibility of event-type-specific fields (create form)
+ */
+function toggleEventFields() {
+    const eventType = getSelectedEventType(false);
+    const config = EVENT_FORM_CONFIG[eventType];
+
+    if (!config) return;
+
+    // Hide all possible sections first
+    const allSections = ['sabc-tournament-fields', 'other-tournament-fields',
+                        'other-tournament-description', 'other-fields', 'sabc-fields', 'holiday-fields'];
+    hideAllSections(allSections);
+
+    // Show relevant sections for this event type
+    showSections(config.visibleSections);
+
+    // Clear requirements and set new ones
+    clearAllRequirements();
+    setFieldRequirements(config.requiredFields);
+
+    // Handle description field visibility
+    manageDescriptionFields(config.descriptionField);
+
+    // Set default values
+    setFieldDefaults(config.defaults);
+
+    // Update name field requirement indicator
+    const nameRequired = document.getElementById('name-required');
+    if (nameRequired) {
+        nameRequired.style.display = eventType === 'holiday' ? 'none' : 'inline';
+    }
+}
+
+/**
+ * Toggle visibility of event-type-specific fields (edit form)
+ */
+function toggleEditEventFields() {
+    const eventType = getSelectedEventType(true);
+    const config = EVENT_FORM_CONFIG[eventType];
+
+    if (!config) return;
+
+    // Hide all edit sections first
+    const allEditSections = ['edit-tournament-fields', 'edit-sabc-fields', 'edit-holiday-fields'];
+    hideAllSections(allEditSections);
+
+    // Show relevant edit sections using 'block' display
+    showSections(config.editSections, 'block');
+}

--- a/static/admin-events-lakes.js
+++ b/static/admin-events-lakes.js
@@ -1,0 +1,101 @@
+/**
+ * Admin Events - Lake/Ramp Loading Module
+ * Handles loading lakes data and populating lake/ramp dropdowns
+ */
+
+// Shared lakes data cache
+let lakesData = [];
+
+/**
+ * Load lakes data from API and populate all lake dropdowns
+ */
+function loadLakes() {
+    fetch('/api/lakes')
+        .then(response => response.json())
+        .then(lakes => {
+            lakesData = lakes;
+            // Populate create form lake select
+            const createLakeSelect = document.getElementById('lake_name');
+            if (createLakeSelect) {
+                createLakeSelect.innerHTML = '<option value="">-- Select Lake --</option>';
+                lakes.forEach(lake => {
+                    const option = document.createElement('option');
+                    option.value = lake.name;
+                    option.textContent = lake.name;
+                    option.dataset.lakeKey = lake.key;
+                    createLakeSelect.appendChild(option);
+                });
+            }
+
+            // Populate edit form lake select
+            const editLakeSelect = document.getElementById('edit_lake_name');
+            if (editLakeSelect) {
+                editLakeSelect.innerHTML = '<option value="">-- Select Lake --</option>';
+                lakes.forEach(lake => {
+                    const option = document.createElement('option');
+                    option.value = lake.name;
+                    option.textContent = lake.name;
+                    option.dataset.lakeKey = lake.key;
+                    editLakeSelect.appendChild(option);
+                });
+            }
+
+            // Populate other tournament lake select
+            loadLakesForOtherTournament();
+        });
+}
+
+/**
+ * Load boat ramps for a selected lake using LakeRampSelector component
+ * Fetches ramps from API and populates the specified select element
+ *
+ * @param {string} lakeName - Name of the lake to load ramps for
+ * @param {string} rampSelectId - ID of the select element to populate (default: 'edit_ramp_name')
+ * @returns {Promise<void>} Promise that resolves when ramps are loaded
+ */
+async function loadRamps(lakeName, rampSelectId = 'edit_ramp_name') {
+    // Create a temporary lake select ID (not used but required by component)
+    const tempLakeId = `temp_lake_for_${rampSelectId}`;
+
+    const selector = new LakeRampSelector({
+        lakeSelectId: tempLakeId,
+        rampSelectId: rampSelectId,
+        lakesData: lakesData,
+        useApi: true
+    });
+
+    await selector.loadRampsForLake(lakeName);
+}
+
+/**
+ * Populate other tournament lake dropdown from cached lakesData
+ */
+function loadLakesForOtherTournament() {
+    const lakeSelect = document.getElementById('other_lake_name');
+    if (lakeSelect && lakesData.length > 0) {
+        lakeSelect.innerHTML = '<option value="">-- Select Lake (Optional) --</option>';
+        lakesData.forEach(lake => {
+            const option = document.createElement('option');
+            option.value = lake.name;
+            option.textContent = lake.name;
+            option.dataset.lakeKey = lake.key;
+            lakeSelect.appendChild(option);
+        });
+    }
+}
+
+/**
+ * Get the current lakes data cache
+ * @returns {Array} The cached lakes data
+ */
+function getLakesData() {
+    return lakesData;
+}
+
+/**
+ * Set the lakes data cache (used when loading data externally)
+ * @param {Array} data - Lakes data to cache
+ */
+function setLakesData(data) {
+    lakesData = data;
+}

--- a/static/admin-events.js
+++ b/static/admin-events.js
@@ -1,68 +1,23 @@
 /**
- * SABC Admin Events Management
- * JavaScript for /admin/events page - event creation, editing, filtering
+ * SABC Admin Events Management - Core Module
+ * JavaScript for /admin/events page - event editing, deletion, and initialization
+ *
+ * This module depends on:
+ * - admin-events-lakes.js (lake/ramp loading)
+ * - admin-events-forms.js (form field management)
+ * - admin-events-filters.js (event filtering)
+ * - utils.js (LakeRampSelector, formatDateTimeLocal, deleteRequest, showToast)
  */
-
-// Load lakes when page loads
-let lakesData = [];
-function loadLakes() {
-    fetch('/api/lakes')
-        .then(response => response.json())
-        .then(lakes => {
-            lakesData = lakes;
-            // Populate create form lake select
-            const createLakeSelect = document.getElementById('lake_name');
-            if (createLakeSelect) {
-                createLakeSelect.innerHTML = '<option value="">-- Select Lake --</option>';
-                lakes.forEach(lake => {
-                    const option = document.createElement('option');
-                    option.value = lake.name;
-                    option.textContent = lake.name;
-                    option.dataset.lakeKey = lake.key;
-                    createLakeSelect.appendChild(option);
-                });
-            }
-
-            // Populate edit form lake select
-            const editLakeSelect = document.getElementById('edit_lake_name');
-            if (editLakeSelect) {
-                editLakeSelect.innerHTML = '<option value="">-- Select Lake --</option>';
-                lakes.forEach(lake => {
-                    const option = document.createElement('option');
-                    option.value = lake.name;
-                    option.textContent = lake.name;
-                    option.dataset.lakeKey = lake.key;
-                    editLakeSelect.appendChild(option);
-                });
-            }
-
-            // Populate other tournament lake select
-            loadLakesForOtherTournament();
-        });
-}
 
 /**
- * Load boat ramps for a selected lake using LakeRampSelector component
- * Fetches ramps from API and populates the specified select element
- *
- * @param {string} lakeName - Name of the lake to load ramps for
- * @param {string} rampSelectId - ID of the select element to populate (default: 'edit_ramp_name')
- * @returns {Promise<void>} Promise that resolves when ramps are loaded
+ * Edit an event - loads event data and shows edit modal
+ * @param {number} id - Event ID
+ * @param {string} date - Event date
+ * @param {string} eventType - Event type
+ * @param {string} name - Event name
+ * @param {string} description - Event description
+ * @param {boolean} hasPoll - Whether event has a poll
  */
-async function loadRamps(lakeName, rampSelectId = 'edit_ramp_name') {
-    // Create a temporary lake select ID (not used but required by component)
-    const tempLakeId = `temp_lake_for_${rampSelectId}`;
-
-    const selector = new LakeRampSelector({
-        lakeSelectId: tempLakeId,
-        rampSelectId: rampSelectId,
-        lakesData: lakesData,
-        useApi: true
-    });
-
-    await selector.loadRampsForLake(lakeName);
-}
-
 function editEvent(id, date, eventType, name, description, hasPoll) {
     // Ensure lakes are loaded before proceeding
     const ensureLakesLoadedAndEdit = () => {
@@ -158,11 +113,12 @@ function editEvent(id, date, eventType, name, description, hasPoll) {
     };
 
     // Check if lakes are already loaded
-    if (lakesData.length === 0) {
+    const currentLakesData = getLakesData();
+    if (currentLakesData.length === 0) {
         fetch('/api/lakes')
             .then(response => response.json())
             .then(lakes => {
-                lakesData = lakes;
+                setLakesData(lakes);
                 ensureLakesLoadedAndEdit();
             })
             .catch(error => {
@@ -175,8 +131,13 @@ function editEvent(id, date, eventType, name, description, hasPoll) {
     }
 }
 
+/**
+ * Setup poll fields in edit modal
+ * @param {string} eventType - Event type
+ * @param {boolean} hasPoll - Whether event has a poll
+ * @param {string} pollClosesAt - Poll close datetime
+ */
 function setupPollFields(eventType, hasPoll, pollClosesAt) {
-
     var pollClosesContainer = document.getElementById('edit_poll_closes_container');
     var pollClosesInput = document.getElementById('edit_poll_closes_date');
 
@@ -274,398 +235,6 @@ function deletePastEvent(id, name, hasDependencies) {
 
 function confirmDeletePastEvent() {
     confirmDeleteEvent('past');
-}
-
-// Configuration-driven event form management
-// Base configurations for reuse
-const BASE_TOURNAMENT_CONFIG = {
-    clearFields: ['start_time', 'weigh_in_time'],
-    defaults: { start_time: '06:00', weigh_in_time: '15:00' },
-    requiredFields: []
-};
-
-const EMPTY_CONFIG = {
-    clearFields: [],
-    defaults: {},
-    requiredFields: []
-};
-
-const EVENT_FORM_CONFIG = {
-    sabc_tournament: {
-        ...BASE_TOURNAMENT_CONFIG,
-        visibleSections: ['sabc-tournament-fields'],
-        editSections: ['edit-tournament-fields', 'edit-sabc-fields'],
-        descriptionField: 'description'
-    },
-    holiday: {
-        ...EMPTY_CONFIG,
-        visibleSections: ['holiday-fields'],
-        editSections: ['edit-holiday-fields'],
-        descriptionField: null
-    },
-    other_tournament: {
-        ...EMPTY_CONFIG,
-        visibleSections: ['other-tournament-fields', 'other-tournament-description'],
-        editSections: ['edit-tournament-fields'],
-        descriptionField: 'other_description'
-    }
-};
-
-/**
- * Utility: Hide all specified sections and disable their inputs
- */
-function hideAllSections(sectionIds) {
-    sectionIds.forEach(id => {
-        const section = document.getElementById(id);
-        if (section) {
-            section.style.display = 'none';
-            // Disable all inputs in hidden sections so they don't submit
-            section.querySelectorAll('input, select, textarea').forEach(input => {
-                input.disabled = true;
-            });
-        }
-    });
-}
-
-/**
- * Utility: Show specified sections and enable their inputs
- */
-function showSections(sectionIds, displayType = 'flex') {
-    sectionIds.forEach(id => {
-        const section = document.getElementById(id);
-        if (section) {
-            section.style.display = displayType;
-            // Enable all inputs in visible sections
-            section.querySelectorAll('input, select, textarea').forEach(input => {
-                // Don't enable ramp selects - they're controlled by lake selection
-                if (!input.id.includes('ramp_name')) {
-                    input.disabled = false;
-                }
-            });
-        }
-    });
-}
-
-/**
- * Utility: Clear specified form field values
- */
-function clearFieldValues(fieldIds) {
-    fieldIds.forEach(id => {
-        const field = document.getElementById(id);
-        if (field) field.value = '';
-    });
-}
-
-/**
- * Utility: Set default values for specified fields
- */
-function setFieldDefaults(fieldValueMap) {
-    Object.entries(fieldValueMap).forEach(([fieldId, value]) => {
-        const field = document.getElementById(fieldId);
-        if (field) field.value = value;
-    });
-}
-
-/**
- * Utility: Clear all 'required' attributes from form fields
- */
-function clearAllRequirements() {
-    ['start_time', 'weigh_in_time', 'lake_name', 'ramp_name'].forEach(id => {
-        const field = document.getElementById(id);
-        if (field) field.removeAttribute('required');
-    });
-}
-
-/**
- * Utility: Set 'required' attribute on specified fields
- */
-function setFieldRequirements(requiredIds) {
-    requiredIds.forEach(id => {
-        const field = document.getElementById(id);
-        if (field) field.setAttribute('required', 'required');
-    });
-}
-
-/**
- * Manage description fields based on event type
- */
-function manageDescriptionFields(activeFieldId) {
-    const descriptionField = document.getElementById('description');
-    const otherDescriptionField = document.getElementById('other_description');
-
-    if (activeFieldId === 'other_description') {
-        // Hide general description, show other_description
-        if (descriptionField) {
-            descriptionField.closest('.col-md-3').style.display = 'none';
-            descriptionField.removeAttribute('required');
-        }
-        if (otherDescriptionField) {
-            otherDescriptionField.closest('.col-md-12').style.display = 'block';
-            otherDescriptionField.setAttribute('required', 'required');
-        }
-    } else if (activeFieldId === 'description') {
-        // Show general description, hide other_description
-        if (descriptionField) {
-            descriptionField.closest('.col-md-3').style.display = 'block';
-        }
-        if (otherDescriptionField) {
-            otherDescriptionField.closest('.col-md-12').style.display = 'none';
-            otherDescriptionField.removeAttribute('required');
-        }
-    } else {
-        // No description field active
-        if (descriptionField) {
-            descriptionField.closest('.col-md-3').style.display = 'block';
-        }
-        if (otherDescriptionField) {
-            otherDescriptionField.closest('.col-md-12').style.display = 'none';
-            otherDescriptionField.removeAttribute('required');
-        }
-    }
-}
-
-/**
- * Get selected event type (create or edit mode)
- */
-function getSelectedEventType(isEdit = false) {
-    const selectId = isEdit ? 'edit_event_type' : 'event_type';
-    return document.getElementById(selectId)?.value;
-}
-
-/**
- * Toggle visibility of event-type-specific fields (create form)
- */
-function toggleEventFields() {
-    const eventType = getSelectedEventType(false);
-    const config = EVENT_FORM_CONFIG[eventType];
-
-    if (!config) return;
-
-    // Hide all possible sections first
-    const allSections = ['sabc-tournament-fields', 'other-tournament-fields',
-                        'other-tournament-description', 'other-fields', 'sabc-fields', 'holiday-fields'];
-    hideAllSections(allSections);
-
-    // Show relevant sections for this event type
-    showSections(config.visibleSections);
-
-    // Clear requirements and set new ones
-    clearAllRequirements();
-    setFieldRequirements(config.requiredFields);
-
-    // Handle description field visibility
-    manageDescriptionFields(config.descriptionField);
-
-    // Set default values
-    setFieldDefaults(config.defaults);
-
-    // Update name field requirement indicator
-    const nameRequired = document.getElementById('name-required');
-    if (nameRequired) {
-        nameRequired.style.display = eventType === 'holiday' ? 'none' : 'inline';
-    }
-}
-
-/**
- * Toggle visibility of event-type-specific fields (edit form)
- */
-function toggleEditEventFields() {
-    const eventType = getSelectedEventType(true);
-    const config = EVENT_FORM_CONFIG[eventType];
-
-    if (!config) return;
-
-    // Hide all edit sections first
-    const allEditSections = ['edit-tournament-fields', 'edit-sabc-fields', 'edit-holiday-fields'];
-    hideAllSections(allEditSections);
-
-    // Show relevant edit sections using 'block' display
-    showSections(config.editSections, 'block');
-}
-
-/**
- * Populate other tournament lake dropdown from cached lakesData
- */
-function loadLakesForOtherTournament() {
-    const lakeSelect = document.getElementById('other_lake_name');
-    if (lakeSelect && lakesData.length > 0) {
-        lakeSelect.innerHTML = '<option value="">-- Select Lake (Optional) --</option>';
-        lakesData.forEach(lake => {
-            const option = document.createElement('option');
-            option.value = lake.name;
-            option.textContent = lake.name;
-            option.dataset.lakeKey = lake.key;
-            lakeSelect.appendChild(option);
-        });
-    }
-}
-
-/**
- * Filter events in a specific tab
- */
-function filterEvents(tabType) {
-    const searchInput = document.getElementById(`${tabType}-search`).value.toLowerCase();
-    const yearFilter = document.getElementById(`${tabType}-year-filter`)?.value;
-    const statusFilter = document.getElementById(`${tabType}-status-filter`)?.value;
-    const lakeFilter = document.getElementById(`${tabType}-lake-filter`)?.value.toLowerCase();
-    const typeFilter = document.getElementById(`${tabType}-type-filter`)?.value;
-    const resultsFilter = document.getElementById(`${tabType}-results-filter`)?.value;
-
-    // Determine the correct table selector based on tab type
-    let tableSelector;
-    if (tabType === 'past') {
-        tableSelector = '#past-events-tab table tbody tr';
-    } else if (tabType === 'past-tournaments') {
-        tableSelector = '#past-tournaments-events table tbody tr';
-    } else {
-        tableSelector = `#${tabType}-events table tbody tr`;
-    }
-
-    const rows = document.querySelectorAll(tableSelector);
-    let visibleCount = 0;
-
-    rows.forEach(row => {
-        // Skip rows with no data cells (e.g., empty state messages)
-        if (row.cells.length < 3) {
-            return;
-        }
-
-        let visible = true;
-
-        // Search filter
-        if (searchInput && !row.textContent.toLowerCase().includes(searchInput)) {
-            visible = false;
-        }
-
-        // Year filter
-        if (yearFilter && row.dataset.year !== yearFilter) {
-            visible = false;
-        }
-
-        // Status filter (for SABC tournaments)
-        if (statusFilter) {
-            if (statusFilter === 'has-poll' && !row.textContent.includes('🗳️')) {
-                visible = false;
-            }
-            if (statusFilter === 'no-poll' && row.textContent.includes('🗳️')) {
-                visible = false;
-            }
-            if (statusFilter === 'complete' && !row.textContent.includes('✅')) {
-                visible = false;
-            }
-            if (statusFilter === 'incomplete' && row.textContent.includes('✅')) {
-                visible = false;
-            }
-        }
-
-        // Lake filter
-        if (lakeFilter && row.dataset.lake && !row.dataset.lake.includes(lakeFilter)) {
-            visible = false;
-        }
-
-        // Type filter
-        if (typeFilter && row.dataset.eventType !== typeFilter) {
-            visible = false;
-        }
-
-        // Results filter
-        if (resultsFilter) {
-            const hasResults = row.dataset.hasResults === 'yes';
-            if (resultsFilter === 'has-results' && !hasResults) {
-                visible = false;
-            }
-            if (resultsFilter === 'no-results' && hasResults) {
-                visible = false;
-            }
-        }
-
-        row.style.display = visible ? '' : 'none';
-        if (visible) visibleCount++;
-    });
-
-    // Update empty state
-    updateEmptyState(tabType, visibleCount);
-}
-
-function clearFilters(tabType) {
-    // Clear all filter inputs for this tab
-    document.getElementById(`${tabType}-search`).value = '';
-
-    const yearFilter = document.getElementById(`${tabType}-year-filter`);
-    if (yearFilter) yearFilter.value = '';
-
-    const statusFilter = document.getElementById(`${tabType}-status-filter`);
-    if (statusFilter) statusFilter.value = '';
-
-    const lakeFilter = document.getElementById(`${tabType}-lake-filter`);
-    if (lakeFilter) lakeFilter.value = '';
-
-    const typeFilter = document.getElementById(`${tabType}-type-filter`);
-    if (typeFilter) typeFilter.value = '';
-
-    const resultsFilter = document.getElementById(`${tabType}-results-filter`);
-    if (resultsFilter) resultsFilter.value = '';
-
-    // Show all rows
-    let tableSelector;
-    if (tabType === 'past') {
-        tableSelector = '#past-events-tab table tbody tr';
-    } else if (tabType === 'past-tournaments') {
-        tableSelector = '#past-tournaments-events table tbody tr';
-    } else {
-        tableSelector = `#${tabType}-events table tbody tr`;
-    }
-
-    const rows = document.querySelectorAll(tableSelector);
-    let visibleCount = 0;
-
-    rows.forEach(row => {
-        if (row.cells.length > 2 && !row.textContent.includes('No events')) {
-            row.style.display = '';
-            visibleCount++;
-        }
-    });
-
-    updateEmptyState(tabType, visibleCount);
-}
-
-function updateEmptyState(tabType, visibleCount) {
-    // Update tab badges with filtered counts
-    let badgeId;
-    if (tabType === 'sabc') badgeId = 'sabc-count';
-    else if (tabType === 'holidays') badgeId = 'holidays-count';
-    else if (tabType === 'other') badgeId = 'other-count';
-    else if (tabType === 'past-tournaments') badgeId = 'past-tournaments-count';
-    else if (tabType === 'past') badgeId = 'past-count';
-
-    const tabBadge = document.getElementById(badgeId);
-
-    if (tabBadge && visibleCount !== undefined) {
-        // Store original count if not already stored
-        if (!tabBadge.dataset.originalCount) {
-            tabBadge.dataset.originalCount = tabBadge.textContent;
-        }
-
-        // Show filtered count if different from original
-        if (document.getElementById(`${tabType}-search`).value ||
-            document.getElementById(`${tabType}-year-filter`)?.value ||
-            document.getElementById(`${tabType}-status-filter`)?.value ||
-            document.getElementById(`${tabType}-lake-filter`)?.value ||
-            document.getElementById(`${tabType}-type-filter`)?.value ||
-            document.getElementById(`${tabType}-results-filter`)?.value) {
-            tabBadge.textContent = visibleCount;
-            tabBadge.classList.add('bg-warning');
-            tabBadge.classList.remove('bg-primary', 'bg-info', 'bg-secondary');
-        } else {
-            tabBadge.textContent = tabBadge.dataset.originalCount;
-            tabBadge.classList.remove('bg-warning');
-            // Restore original badge color based on tab
-            if (tabType === 'sabc') tabBadge.classList.add('bg-primary');
-            else if (tabType === 'holidays') tabBadge.classList.add('bg-info');
-            else if (tabType === 'other') tabBadge.classList.add('bg-warning');
-            else tabBadge.classList.add('bg-secondary');
-        }
-    }
 }
 
 /**

--- a/templates/admin/events.html
+++ b/templates/admin/events.html
@@ -647,5 +647,8 @@
     </div>
 </div>
 
+<script src="/static/admin-events-lakes.js"></script>
+<script src="/static/admin-events-forms.js"></script>
+<script src="/static/admin-events-filters.js"></script>
 <script src="/static/admin-events.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Split the large admin-events.js (730 lines) into 4 focused modules
- admin-events-lakes.js (101 lines) - Lake/ramp data loading
- admin-events-forms.js (211 lines) - Event form configuration  
- admin-events-filters.js (172 lines) - Event filtering and search
- admin-events.js (298 lines) - Core editing, deletion, initialization
- Updated events.html template to load all modules in correct order

## Test plan
- [x] All 891 tests pass
- [x] Code quality checks pass (ruff + mypy)
- [x] Manual test: Create new event on admin events page
- [x] Manual test: Edit existing event
- [x] Manual test: Delete event
- [x] Manual test: Filter events by year/status/lake

🤖 Generated with [Claude Code](https://claude.com/claude-code)