### PR TITLE
Add cancelled tournament display with alert banner (#243)

### DIFF
--- a/routes/admin/events/get_event_info.py
+++ b/routes/admin/events/get_event_info.py
@@ -65,6 +65,9 @@ async def get_event_info(request: Request, event_id: int):
                         "aoy_points": bool(tournament.aoy_points)
                         if tournament and tournament.aoy_points is not None
                         else True,
+                        "is_cancelled": bool(event.is_cancelled)
+                        if event.is_cancelled is not None
+                        else False,
                     }
                 )
             else:

--- a/routes/admin/events/update_event.py
+++ b/routes/admin/events/update_event.py
@@ -57,6 +57,7 @@ async def update_event_by_id(
     fish_limit: int = Form(default=5),
     aoy_points: str = Form(default="true"),
     poll_closes_date: str = Form(default=""),
+    is_cancelled: str = Form(default=""),
 ):
     """POST endpoint for updating an event by ID."""
     _user = require_admin(request)
@@ -83,6 +84,8 @@ async def update_event_by_id(
             fish_limit,
             aoy_points,
         )
+        # Add is_cancelled flag (checkbox sends "true" when checked, empty when not)
+        event_params["is_cancelled"] = is_cancelled.lower() == "true"
 
         with get_session() as session:
             rowcount = update_event_record(session, event_params)
@@ -124,6 +127,7 @@ async def edit_event(
     aoy_points: str = Form(default="true"),
     poll_closes_date: str = Form(default=""),
     poll_id: str = Form(default=""),
+    is_cancelled: str = Form(default=""),
 ):
     _user = require_admin(request)
     try:
@@ -149,6 +153,9 @@ async def edit_event(
             fish_limit,
             aoy_points,
         )
+        # Add is_cancelled flag (checkbox sends "true" when checked, empty when not)
+        event_params["is_cancelled"] = is_cancelled.lower() == "true"
+
         from core.db_schema import get_session
 
         with get_session() as session:

--- a/routes/admin/events/update_helpers.py
+++ b/routes/admin/events/update_helpers.py
@@ -77,6 +77,9 @@ def update_event_record(session: Session, event_params: Dict[str, Any]) -> int:
         event.ramp_name = event_params["ramp_name"]
         event.entry_fee = event_params["entry_fee"]
         event.holiday_name = event_params["holiday_name"]
+        # Update is_cancelled if provided
+        if "is_cancelled" in event_params:
+            event.is_cancelled = event_params["is_cancelled"]
         return 1
     return 0
 

--- a/static/admin-events-forms.js
+++ b/static/admin-events-forms.js
@@ -234,6 +234,12 @@ function toggleEditEventFields() {
 
     // Show relevant edit sections using 'block' display
     showSections(config.editSections, 'block');
+
+    // Show/hide cancel field for tournaments only
+    const cancelField = document.getElementById('edit-cancel-field');
+    if (cancelField) {
+        cancelField.style.display = (eventType === 'sabc_tournament' || eventType === 'other_tournament') ? 'block' : 'none';
+    }
 }
 
 /**

--- a/static/admin-events.js
+++ b/static/admin-events.js
@@ -40,6 +40,12 @@ function editEvent(id, date, eventType, name, description, hasPoll) {
                 // Toggle visibility of event type-specific fields FIRST
                 toggleEditEventFields();
 
+                // Set the cancelled checkbox for tournaments
+                const isCancelledCheckbox = document.getElementById('edit_is_cancelled');
+                if (isCancelledCheckbox) {
+                    isCancelledCheckbox.checked = data.is_cancelled === true;
+                }
+
                 // Handle tournament fields (both SABC and Other tournaments)
                 if (data.event_type === 'sabc_tournament' || data.event_type === 'other_tournament') {
                     // Set tournament-specific fields (times are optional for other_tournament)

--- a/templates/admin/events.html
+++ b/templates/admin/events.html
@@ -518,6 +518,17 @@
                         <input type="text" class="form-control" id="edit_description" name="description">
                     </div>
 
+                    <!-- Cancel Tournament Checkbox (only for tournaments) -->
+                    <div class="mb-3" id="edit-cancel-field" style="display: none;">
+                        <div class="form-check">
+                            <input type="checkbox" class="form-check-input" id="edit_is_cancelled" name="is_cancelled" value="true">
+                            <label class="form-check-label text-danger fw-bold" for="edit_is_cancelled">
+                                <i class="bi bi-exclamation-triangle me-1"></i>Cancel this tournament
+                            </label>
+                            <div class="form-text">Cancelled tournaments will display an alert banner on the home page and be removed from the tournament list.</div>
+                        </div>
+                    </div>
+
                     <!-- Tournament-specific fields -->
                     <div id="edit-tournament-fields" style="display: none;">
                         <div class="row mb-3">

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,27 @@
 <!-- Data passed to JavaScript -->
 <div id="home-data" data-lakes="{{ lakes_data | tojson_attr if lakes_data is defined else '[]' }}"></div>
 
+<!-- Cancelled Tournament Alert Banner -->
+{% if cancelled_tournaments %}
+<div class="row mb-3">
+    <div class="col-12">
+        {% for cancelled in cancelled_tournaments %}
+        <div class="alert alert-danger alert-dismissible fade show d-flex align-items-center" role="alert" id="cancelled-alert-{{ cancelled.id }}">
+            <i class="bi bi-exclamation-triangle-fill me-2 fs-5"></i>
+            <div class="flex-grow-1">
+                <strong>Tournament Cancelled:</strong>
+                The {{ cancelled.date|date_format("mm-dd-yyyy") }} tournament
+                {% if cancelled.lake_name %}at <strong>{{ cancelled.lake_name }}</strong>{% endif %}
+                has been cancelled.
+                {% if cancelled.description %}<span class="text-muted ms-1">({{ cancelled.name }})</span>{% endif %}
+            </div>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" onclick="dismissCancelledAlert({{ cancelled.id }})"></button>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% endif %}
+
 <div class="row">
     <!-- Main Content -->
     <div class="col-lg-8">
@@ -12,7 +33,9 @@
         {# A tournament is "completed" if it has results (complete=True) OR its date has passed (is_past=True) #}
         {% set completed_tournaments = all_tournaments | selectattr('is_past', 'equalto', True) | selectattr('event_type', 'equalto', 'sabc_tournament') | sort(attribute='date', reverse=True) | list %}
         {% set upcoming_tournaments = all_tournaments | rejectattr('is_past', 'equalto', True) | selectattr('event_type', 'equalto', 'sabc_tournament') | sort(attribute='date') | list %}
-        {% set next_tournament = upcoming_tournaments[0] if upcoming_tournaments else none %}
+        {# For "Next Tournament" tab, exclude cancelled tournaments #}
+        {% set active_upcoming = upcoming_tournaments | rejectattr('is_cancelled', 'equalto', true) | list %}
+        {% set next_tournament = active_upcoming[0] if active_upcoming else none %}
         {% set show_completed_tab = current_page > 1 or not upcoming_tournaments %}
 
         <!-- Bootstrap Tabs -->
@@ -453,9 +476,15 @@
                         {% endif %}
 
                         <div class="d-flex justify-content-end">
+                            {% if tournament.is_cancelled %}
+                            <span class="badge bg-danger fs-6 py-2 px-3">
+                                <i class="bi bi-slash-circle me-1"></i>Cancelled
+                            </span>
+                            {% else %}
                             <a href="/tournaments/{{ tournament.id }}" class="btn btn-primary">
                                 <i class="bi bi-eye me-1"></i>View Results
                             </a>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
@@ -536,11 +565,11 @@
             <!-- Upcoming Tournaments Tab -->
             <div class="tab-pane fade" id="upcoming-pane" role="tabpanel" aria-labelledby="upcoming-tab">
                 {% for tournament in upcoming_tournaments %}
-                <div class="card mb-4">
-                    <div class="card-header bg-primary text-white">
+                <div class="card mb-4{% if tournament.is_cancelled %}" style="opacity: 0.6;{% endif %}">
+                    <div class="card-header {% if tournament.is_cancelled %}bg-danger{% else %}bg-primary{% endif %} text-white">
                         <div class="d-flex justify-content-between align-items-center">
                             <div>
-                                <h5 class="mb-0">
+                                <h5 class="mb-0{% if tournament.is_cancelled %} text-decoration-line-through{% endif %}">
                                     {% if tournament.lake_display_name %}
                                         {{ tournament.lake_display_name|upper }}
                                     {% else %}
@@ -560,9 +589,15 @@
                                     </small>
                                 {% endif %}
                             </div>
+                            {% if tournament.is_cancelled %}
+                            <span class="badge bg-light text-danger">
+                                <i class="bi bi-slash-circle me-1"></i>Cancelled
+                            </span>
+                            {% else %}
                             <span class="badge bg-warning text-dark">
                                 Upcoming
                             </span>
+                            {% endif %}
                         </div>
                     </div>
 
@@ -945,5 +980,31 @@
         </div>
     {% endif %}
 {% endfor %}
+
+<!-- Cancelled Tournament Alert Dismissal Script -->
+<script>
+/**
+ * Dismiss a cancelled tournament alert and remember the dismissal in localStorage
+ * @param {number} eventId - The event ID of the cancelled tournament
+ */
+function dismissCancelledAlert(eventId) {
+    const dismissed = JSON.parse(localStorage.getItem('dismissedCancelledAlerts') || '[]');
+    if (!dismissed.includes(eventId)) {
+        dismissed.push(eventId);
+        localStorage.setItem('dismissedCancelledAlerts', JSON.stringify(dismissed));
+    }
+}
+
+// On page load, hide previously dismissed alerts
+document.addEventListener('DOMContentLoaded', function() {
+    const dismissed = JSON.parse(localStorage.getItem('dismissedCancelledAlerts') || '[]');
+    dismissed.forEach(function(eventId) {
+        const alert = document.getElementById('cancelled-alert-' + eventId);
+        if (alert) {
+            alert.remove();
+        }
+    });
+});
+</script>
 
 {% endblock content %}


### PR DESCRIPTION
- Add alert banner on home page for cancelled upcoming tournaments
- Add admin checkbox to mark tournaments as cancelled
- Show cancelled tournaments in Upcoming tab with visual distinction
- Display "Cancelled" badge instead of "View Results" for completed
- Banner is dismissible with localStorage persistence