### PR TITLE
Dues Management: Phase 2 - Auth helper and voting logic

### DIFF
--- a/core/helpers/auth.py
+++ b/core/helpers/auth.py
@@ -1,6 +1,7 @@
 """Authentication and authorization helper functions with full type safety."""
 
-from typing import Annotated, Dict, Optional, Union
+from datetime import date
+from typing import Annotated, Any, Dict, Optional, Union
 from urllib.parse import quote
 
 from fastapi import Depends, HTTPException, Request
@@ -9,6 +10,25 @@ from core.db_schema import engine
 from core.query_service import QueryService
 
 UserDict = Dict[str, Union[int, str, bool, None]]
+
+
+def is_dues_current(user: Dict[str, Any]) -> bool:
+    """
+    Check if user's dues are paid through today or later.
+
+    Args:
+        user: User dictionary with dues_paid_through field
+
+    Returns:
+        True if dues are current (paid through today or later), False otherwise
+    """
+    dues_paid_through = user.get("dues_paid_through")
+    if dues_paid_through is None:
+        return False
+    # Handle case where value comes as string from some query results
+    if isinstance(dues_paid_through, str):
+        dues_paid_through = date.fromisoformat(dues_paid_through)
+    return dues_paid_through >= date.today()
 
 
 def _build_login_redirect_url(request: Request) -> str:

--- a/core/query_service/poll_queries.py
+++ b/core/query_service/poll_queries.py
@@ -1,5 +1,6 @@
 """Poll-related database queries with full type safety."""
 
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from core.query_service.base import QueryServiceBase
@@ -105,3 +106,16 @@ class PollQueries(QueryServiceBase):
                 option["votes"] = votes
                 option["voters"] = [v["voter_name"] for v in votes]
         return options
+
+    def get_latest_poll_created_at(self) -> Optional[datetime]:
+        """
+        Get the created_at timestamp of the most recently created poll.
+
+        Used for the "smart" dues banner dismissal logic - banner reappears
+        when a new poll is created after the user dismissed it.
+
+        Returns:
+            Datetime of most recent poll creation, or None if no polls exist
+        """
+        result = self.fetch_one("SELECT created_at FROM polls ORDER BY created_at DESC LIMIT 1")
+        return result["created_at"] if result else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ os.environ["DEBUG"] = "false"
 os.environ["LOG_LEVEL"] = "ERROR"
 
 # ruff: noqa: E402 - Must set env vars before imports
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, Generator, Optional
 
 import bcrypt
@@ -157,7 +157,7 @@ def regular_user(db_session: Session, password_hash: str) -> Angler:
 
 @pytest.fixture
 def member_user(db_session: Session, password_hash: str) -> Angler:
-    """Create a member (non-admin) user for testing."""
+    """Create a member (non-admin) user for testing with current dues."""
     user = Angler(
         name="Test Member",
         email="member@example.com",
@@ -165,6 +165,7 @@ def member_user(db_session: Session, password_hash: str) -> Angler:
         member=True,
         is_admin=False,
         created_at=datetime.now(tz=timezone.utc),
+        dues_paid_through=date.today() + timedelta(days=365),  # Dues valid for a year
     )
     db_session.add(user)
     db_session.commit()


### PR DESCRIPTION
## Summary
- Add `is_dues_current()` helper function to check if user's dues are paid through today
- Add `get_latest_poll_created_at()` method for smart banner dismissal logic (Phase 3)
- Update voting logic to check dues status before allowing votes
- Admins bypass dues check and can always vote
- Update test fixtures to include `dues_paid_through` for member users

## Files Changed
- `core/helpers/auth.py` - Added `is_dues_current()` helper
- `core/query_service/poll_queries.py` - Added `get_latest_poll_created_at()` method
- `routes/voting/vote_poll.py` - Added dues check after member check
- `tests/conftest.py` - Updated member_user fixture with current dues

## Test plan
- [x] All 909 tests pass
- [x] `check-code` passes (mypy + ruff)
- [ ] Manual test: member with expired dues cannot vote
- [ ] Manual test: admin with expired dues CAN vote

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)