### PR TITLE
Dues Management: Phase 3 - Banner UI and dismiss endpoint

### DIFF
--- a/routes/voting/vote_poll.py
+++ b/routes/voting/vote_poll.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, Form, Request
 from fastapi.responses import RedirectResponse
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
-from core.db_schema import Poll, PollOption, PollVote, get_session
+from core.db_schema import Angler, Poll, PollOption, PollVote, get_session
 from core.helpers.auth import is_dues_current, require_auth
 from core.helpers.logging import get_logger
 from core.helpers.response import sanitize_error_message
@@ -272,3 +272,37 @@ async def vote_in_poll(
             exc_info=True,
         )
         return RedirectResponse(f"/polls?error={error_msg}", status_code=303)
+
+
+@router.post("/dismiss-dues-banner")
+async def dismiss_dues_banner(
+    request: Request,
+    user: Dict[str, Any] = Depends(require_auth),
+) -> RedirectResponse:
+    """
+    Dismiss the dues reminder banner for the current user.
+
+    Sets dues_banner_dismissed_at to current timestamp. The banner will
+    reappear when a new poll is created (smart dismiss logic).
+    """
+    user_id = user.get("id")
+    if user_id:
+        try:
+            with get_session() as session:
+                angler = session.query(Angler).filter(Angler.id == user_id).first()
+                if angler:
+                    angler.dues_banner_dismissed_at = now_local()
+                    session.commit()
+                    logger.info(
+                        "Dues banner dismissed",
+                        extra={"user_id": user_id},
+                    )
+        except SQLAlchemyError as e:
+            logger.error(
+                "Failed to dismiss dues banner",
+                extra={"user_id": user_id, "error": str(e)},
+            )
+
+    # Return to previous page or polls
+    referer = request.headers.get("referer", "/polls")
+    return RedirectResponse(referer, status_code=303)

--- a/templates/polls.html
+++ b/templates/polls.html
@@ -18,6 +18,19 @@
 {{ alert('danger', request.query_params.get('error')) }}
 {{ alert('success', request.query_params.get('success')) }}
 
+<!-- Dues Reminder Banner -->
+{% if show_dues_banner %}
+<div class="alert alert-warning alert-dismissible fade show" role="alert">
+    <i class="bi bi-exclamation-triangle-fill me-2"></i>
+    <strong>Dues Required:</strong> Your club dues have expired.
+    Please pay your annual dues to vote in polls.
+    <form method="POST" action="/dismiss-dues-banner" class="d-inline float-end">
+        {{ csrf_token(request) }}
+        <button type="submit" class="btn-close" aria-label="Dismiss"></button>
+    </form>
+</div>
+{% endif %}
+
 <!-- Bootstrap Tabs -->
 <ul class="nav nav-tabs mb-4" id="pollTabs" role="tablist">
     <li class="nav-item" role="presentation">


### PR DESCRIPTION
## Summary
- Add `POST /dismiss-dues-banner` endpoint to dismiss the dues reminder banner
- Calculate `show_dues_banner` in list_polls.py with smart dismiss logic
- Banner reappears when a new poll is created after dismissal (smart dismiss)
- Admins never see the banner (they can always vote)
- Add warning banner to polls.html template with dismiss button

## Smart Dismiss Logic
1. User dismisses banner -> `dues_banner_dismissed_at` timestamp saved
2. Banner stays hidden until new poll is created
3. New poll created -> banner reappears for lapsed members who dismissed it

## Files Changed
- `routes/voting/vote_poll.py` - Added dismiss endpoint
- `routes/voting/list_polls.py` - Added banner visibility logic
- `templates/polls.html` - Added dismissable banner UI

## Test plan
- [x] All 909 tests pass
- [x] `check-code` passes (mypy + ruff)
- [ ] Manual test: lapsed member sees banner on /polls
- [ ] Manual test: admin does NOT see banner
- [ ] Manual test: dismiss button hides banner
- [ ] Manual test: creating new poll makes banner reappear

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)