### PR TITLE
Address duplicate code in admin/core.py

### DIFF
--- a/routes/admin/core/dashboard.py
+++ b/routes/admin/core/dashboard.py
@@ -2,13 +2,13 @@ from typing import Any, Dict
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import RedirectResponse
-from sqlalchemy import Date, Integer, cast, exists, func, select
+from sqlalchemy import Date, Integer, cast, func
 
-from core.db_schema import Event, Poll, Result, Tournament, get_session
+from core.db_schema import Event, Poll, get_session
 from core.helpers.auth import require_admin
 from core.helpers.timezone import now_local
 from routes.admin.core.dashboard_data import get_tournaments_data, get_users_data
-from routes.admin.core.event_queries import get_upcoming_events_data
+from routes.admin.core.event_queries import get_sabc_tournaments, get_upcoming_events_data
 from routes.dependencies import templates
 
 router = APIRouter()
@@ -38,121 +38,11 @@ async def admin_page(request: Request, page: str, upcoming_page: int = 1, past_p
         events, total_upcoming = get_upcoming_events_data(upcoming_page, per_page)
         ctx["events"] = events
 
+        # Get ALL past and upcoming SABC tournaments (no pagination for client-side filtering)
+        past_tournaments = get_sabc_tournaments("past")
+        upcoming_sabc_tournaments = get_sabc_tournaments("upcoming")
+
         with get_session() as session:
-            # Get ALL past tournaments for Past Tournaments tab (no pagination for client-side filtering)
-            past_tournaments_query = (
-                session.query(
-                    Event.id,
-                    Event.date,
-                    Event.name,
-                    Event.description,
-                    Event.event_type,
-                    Event.entry_fee,
-                    Event.lake_name,
-                    Event.start_time,
-                    Event.weigh_in_time,
-                    Event.holiday_name,
-                    exists(select(1).where(Poll.event_id == Event.id).correlate_except(Poll)).label(
-                        "has_poll"
-                    ),
-                    exists(
-                        select(1)
-                        .where(Tournament.event_id == Event.id)
-                        .correlate_except(Tournament)
-                    ).label("has_tournament"),
-                    func.coalesce(Tournament.complete, False).label("tournament_complete"),
-                    exists(
-                        select(1)
-                        .where(Result.tournament_id == Tournament.id)
-                        .correlate_except(Result)
-                    ).label("has_results"),
-                )
-                .outerjoin(Tournament, Event.id == Tournament.event_id)
-                .filter(
-                    Event.date < cast(func.current_date(), Date),
-                    Event.event_type == "sabc_tournament",
-                )
-                .order_by(Event.date.desc())
-                .all()
-            )
-
-            past_tournaments = [
-                {
-                    "id": e[0],
-                    "date": e[1],
-                    "name": e[2] or "",
-                    "description": e[3] or "",
-                    "event_type": e[4] or "sabc_tournament",
-                    "entry_fee": e[5],
-                    "lake_name": e[6],
-                    "start_time": e[7],
-                    "weigh_in_time": e[8],
-                    "holiday_name": e[9],
-                    "has_poll": bool(e[10]),
-                    "has_tournament": bool(e[11]),
-                    "tournament_complete": bool(e[12]),
-                    "has_results": bool(e[13]),
-                }
-                for e in past_tournaments_query
-            ]
-
-            # Get ALL upcoming SABC tournaments (no pagination for client-side filtering)
-            upcoming_sabc_query = (
-                session.query(
-                    Event.id,
-                    Event.date,
-                    Event.name,
-                    Event.description,
-                    Event.event_type,
-                    Event.entry_fee,
-                    Event.lake_name,
-                    Event.start_time,
-                    Event.weigh_in_time,
-                    Event.holiday_name,
-                    exists(select(1).where(Poll.event_id == Event.id).correlate_except(Poll)).label(
-                        "has_poll"
-                    ),
-                    exists(
-                        select(1)
-                        .where(Tournament.event_id == Event.id)
-                        .correlate_except(Tournament)
-                    ).label("has_tournament"),
-                    func.coalesce(Tournament.complete, False).label("tournament_complete"),
-                    exists(
-                        select(1)
-                        .where((Poll.event_id == Event.id) & (Poll.closed.is_(False)))
-                        .correlate_except(Poll)
-                    ).label("poll_active"),
-                )
-                .outerjoin(Tournament, Event.id == Tournament.event_id)
-                .filter(
-                    Event.date >= cast(func.current_date(), Date),
-                    Event.event_type == "sabc_tournament",
-                )
-                .order_by(Event.date)
-                .all()
-            )
-
-            upcoming_sabc_tournaments = [
-                {
-                    "id": e[0],
-                    "date": e[1],
-                    "name": e[2] or "",
-                    "description": e[3] or "",
-                    "event_type": e[4] or "sabc_tournament",
-                    "entry_fee": e[5],
-                    "lake_name": e[6],
-                    "start_time": e[7],
-                    "weigh_in_time": e[8],
-                    "holiday_name": e[9],
-                    "has_poll": bool(e[10]),
-                    "has_tournament": bool(e[11]),
-                    "tournament_complete": bool(e[12]),
-                    "poll_active": bool(e[13]),
-                }
-                for e in upcoming_sabc_query
-            ]
-
             # Get years for Past Tournaments tab filter
             year_col = func.extract("year", Event.date).cast(Integer)
             past_tournament_years_query = (

--- a/routes/admin/core/event_queries.py
+++ b/routes/admin/core/event_queries.py
@@ -1,8 +1,116 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal
 
 from sqlalchemy import Date, cast, exists, func, select
+from sqlalchemy.orm import Session
 
 from core.db_schema import Event, Poll, Result, Tournament, get_session
+
+
+def _build_sabc_tournament_query(
+    session: Session,
+    time_filter: Literal["past", "upcoming"],
+) -> List[Dict[str, Any]]:
+    """Build a query for SABC tournaments with common fields.
+
+    Args:
+        session: Database session
+        time_filter: "past" for past tournaments, "upcoming" for future ones
+
+    Returns:
+        List of tournament dictionaries with event details
+    """
+    # Common columns for both queries
+    base_columns = [
+        Event.id,
+        Event.date,
+        Event.name,
+        Event.description,
+        Event.event_type,
+        Event.entry_fee,
+        Event.lake_name,
+        Event.start_time,
+        Event.weigh_in_time,
+        Event.holiday_name,
+        exists(select(1).where(Poll.event_id == Event.id).correlate_except(Poll)).label("has_poll"),
+        exists(select(1).where(Tournament.event_id == Event.id).correlate_except(Tournament)).label(
+            "has_tournament"
+        ),
+        func.coalesce(Tournament.complete, False).label("tournament_complete"),
+    ]
+
+    # Add time-specific column
+    if time_filter == "past":
+        base_columns.append(
+            exists(
+                select(1).where(Result.tournament_id == Tournament.id).correlate_except(Result)
+            ).label("has_results")
+        )
+    else:
+        base_columns.append(
+            exists(
+                select(1)
+                .where((Poll.event_id == Event.id) & (Poll.closed.is_(False)))
+                .correlate_except(Poll)
+            ).label("poll_active")
+        )
+
+    # Build query with appropriate filter and order
+    query = session.query(*base_columns).outerjoin(Tournament, Event.id == Tournament.event_id)
+
+    if time_filter == "past":
+        query = query.filter(
+            Event.date < cast(func.current_date(), Date),
+            Event.event_type == "sabc_tournament",
+        ).order_by(Event.date.desc())
+    else:
+        query = query.filter(
+            Event.date >= cast(func.current_date(), Date),
+            Event.event_type == "sabc_tournament",
+        ).order_by(Event.date)
+
+    results = query.all()
+
+    # Convert to dictionaries
+    tournaments = []
+    for e in results:
+        tournament_dict: Dict[str, Any] = {
+            "id": e[0],
+            "date": e[1],
+            "name": e[2] or "",
+            "description": e[3] or "",
+            "event_type": e[4] or "sabc_tournament",
+            "entry_fee": e[5],
+            "lake_name": e[6],
+            "start_time": e[7],
+            "weigh_in_time": e[8],
+            "holiday_name": e[9],
+            "has_poll": bool(e[10]),
+            "has_tournament": bool(e[11]),
+            "tournament_complete": bool(e[12]),
+        }
+        # Add time-specific field
+        if time_filter == "past":
+            tournament_dict["has_results"] = bool(e[13])
+        else:
+            tournament_dict["poll_active"] = bool(e[13])
+        tournaments.append(tournament_dict)
+
+    return tournaments
+
+
+def get_sabc_tournaments(
+    time_filter: Literal["past", "upcoming"],
+) -> List[Dict[str, Any]]:
+    """Get SABC tournaments with all details for admin dashboard.
+
+    Args:
+        time_filter: "past" for past tournaments, "upcoming" for future ones
+
+    Returns:
+        List of tournament dictionaries
+    """
+    with get_session() as session:
+        return _build_sabc_tournament_query(session, time_filter)
 
 
 def get_upcoming_events_data(page: int, per_page: int) -> tuple[List[Dict[str, Any]], int]:


### PR DESCRIPTION
## Summary
- Extracted duplicate SABC tournament query code from `dashboard.py` into shared `get_sabc_tournaments()` function in `event_queries.py`
- The past and upcoming tournament queries had nearly identical structure (~110 lines each) differing only in filter conditions and one output field
- Reduces `dashboard.py` from 237 to 127 lines by eliminating code duplication
- Removes now-unused imports from `dashboard.py`

## Test plan
- [ ] Verify admin events page loads correctly with past tournaments tab
- [ ] Verify admin events page loads correctly with upcoming SABC tournaments tab  
- [ ] Verify tournament data displays correctly (has_poll, has_tournament, tournament_complete, has_results/poll_active fields)

Fixes #267

Code scanning alert: https://github.com/envasquez/SABC/security/code-scanning/4819

🤖 Generated with [Claude Code](https://claude.com/claude-code)