### PR TITLE
Add contact form to About page

### DIFF
--- a/core/email/__init__.py
+++ b/core/email/__init__.py
@@ -1,4 +1,4 @@
-from .service import send_news_notification, send_password_reset_email
+from .service import send_contact_email, send_news_notification, send_password_reset_email
 from .tokens import (
     cleanup_expired_tokens,
     create_password_reset_token,
@@ -7,6 +7,7 @@ from .tokens import (
 )
 
 __all__ = [
+    "send_contact_email",
     "send_password_reset_email",
     "send_news_notification",
     "create_password_reset_token",

--- a/core/email/service.py
+++ b/core/email/service.py
@@ -12,7 +12,11 @@ from .config import (
     TEST_EMAIL_OVERRIDE,
     logger,
 )
-from .templates import generate_news_email_content, generate_reset_email_content
+from .templates import (
+    generate_contact_email_content,
+    generate_news_email_content,
+    generate_reset_email_content,
+)
 
 
 def send_password_reset_email(email: str, name: str, token: str) -> bool:
@@ -103,4 +107,68 @@ def send_news_notification(
 
     except Exception as e:
         logger.error(f"Failed to send news notification '{title}': {e}")
+        return False
+
+
+def send_contact_email(
+    admin_emails: List[str],
+    sender_name: str,
+    sender_email: str,
+    subject_line: str,
+    message: str,
+) -> bool:
+    """Send a contact form submission to all admin users.
+
+    Args:
+        admin_emails: List of admin email addresses
+        sender_name: Name of the person submitting the form
+        sender_email: Email of the person submitting the form
+        subject_line: Subject provided by the sender
+        message: Message body from the contact form
+
+    Returns:
+        True if email sent successfully, False otherwise
+    """
+    if not SMTP_USERNAME or not SMTP_PASSWORD:
+        logger.warning("SMTP credentials not configured - cannot send contact email")
+        return False
+
+    if not admin_emails:
+        logger.info("No admin email addresses provided - skipping contact email")
+        return False
+
+    # Override recipients for testing
+    if TEST_EMAIL_OVERRIDE:
+        original_count = len(admin_emails)
+        admin_emails = [TEST_EMAIL_OVERRIDE]
+        logger.info(
+            f"TEST MODE: Redirecting contact email from {original_count} admins to {TEST_EMAIL_OVERRIDE}"
+        )
+
+    try:
+        subject, text_body, html_body = generate_contact_email_content(
+            sender_name, sender_email, subject_line, message
+        )
+
+        msg = MIMEMultipart("alternative")
+        msg["From"] = FROM_EMAIL
+        msg["To"] = ", ".join(admin_emails)
+        msg["Reply-To"] = sender_email
+        msg["Subject"] = subject
+
+        msg.attach(MIMEText(text_body, "plain"))
+        msg.attach(MIMEText(html_body, "html"))
+
+        with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as server:
+            server.starttls()
+            server.login(SMTP_USERNAME, SMTP_PASSWORD)
+            server.send_message(msg)
+
+        logger.info(
+            f"Contact email sent to {len(admin_emails)} admins from {sender_email}: {subject_line}"
+        )
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to send contact email from {sender_email}: {e}")
         return False

--- a/core/email/templates.py
+++ b/core/email/templates.py
@@ -102,3 +102,60 @@ The {CLUB_NAME} Team{author_line}
 """
 
     return subject, text_body, html_body
+
+
+def generate_contact_email_content(
+    sender_name: str, sender_email: str, subject_line: str, message: str
+) -> tuple[str, str, str]:
+    """Generate email content for contact form submissions.
+
+    Args:
+        sender_name: Name of the person submitting the form
+        sender_email: Email of the person submitting the form
+        subject_line: Subject provided by the sender
+        message: Message body from the contact form
+
+    Returns:
+        Tuple of (subject, text_body, html_body)
+    """
+    subject = f"{CLUB_NAME} - Contact: {subject_line}"
+
+    text_body = f"""
+New contact form submission from {WEBSITE_URL}:
+
+From: {sender_name} ({sender_email})
+Subject: {subject_line}
+
+{message}
+
+---
+This message was sent via the {CLUB_NAME} website contact form.
+You can reply directly to {sender_email}.
+"""
+
+    # Convert message line breaks to HTML
+    html_message = "".join(
+        f"<p>{line}</p>" if line.strip() else "<br>" for line in message.split("\n")
+    )
+
+    html_body = f"""
+<html>
+<body>
+<p>New contact form submission from <a href="{WEBSITE_URL}">{CLUB_NAME}</a>:</p>
+<table style="border-collapse: collapse; margin: 16px 0;">
+<tr><td style="padding: 4px 12px 4px 0; font-weight: bold;">From:</td><td>{sender_name} ({sender_email})</td></tr>
+<tr><td style="padding: 4px 12px 4px 0; font-weight: bold;">Subject:</td><td>{subject_line}</td></tr>
+</table>
+<div style="padding: 12px; background-color: #f5f5f5; border-left: 4px solid #0d6efd; margin: 16px 0;">
+{html_message}
+</div>
+<hr>
+<p style="color: #6c757d; font-size: 0.875em;">
+This message was sent via the {CLUB_NAME} website contact form.
+You can reply directly to <a href="mailto:{sender_email}">{sender_email}</a>.
+</p>
+</body>
+</html>
+"""
+
+    return subject, text_body, html_body

--- a/routes/pages/home.py
+++ b/routes/pages/home.py
@@ -22,7 +22,10 @@ from core.db_schema import (
     get_session,
 )
 from core.deps import templates
+from core.email import send_contact_email
 from core.helpers.auth import get_user_optional
+from core.helpers.logging import get_logger
+from core.helpers.response import error_redirect, success_redirect
 from core.query_service import QueryService
 from routes.dependencies import get_lakes_list, get_ramps_for_lake
 
@@ -416,6 +419,51 @@ async def home_paginated(request: Request, page: int = 1):
 @router.get("/")
 async def page(request: Request, p: int = 1):
     return await home_paginated(request, p)
+
+
+logger = get_logger(__name__)
+
+EXCLUDED_EMAIL_DOMAINS = ("@sabc.com", "@saustinbc.com")
+
+
+@router.post("/about/contact")
+async def contact_form(request: Request) -> RedirectResponse:
+    """Handle contact form submission - sends email to all admins."""
+    form = await request.form()
+    sender_name = str(form.get("name", "")).strip()
+    sender_email = str(form.get("email", "")).strip()
+    subject_line = str(form.get("subject", "")).strip()
+    message = str(form.get("message", "")).strip()
+
+    if not all([sender_name, sender_email, subject_line, message]):
+        return error_redirect("/about", "All fields are required.")
+
+    # Get admin emails, excluding placeholder domains
+    with get_session() as session:
+        admin_emails: List[str] = [
+            email
+            for (email,) in session.query(Angler.email)
+            .filter(Angler.is_admin == True, Angler.email.isnot(None))  # noqa: E712
+            .all()
+            if email
+            and not any(email.lower().endswith(domain) for domain in EXCLUDED_EMAIL_DOMAINS)
+        ]
+
+    if not admin_emails:
+        logger.warning("No admin emails found for contact form submission")
+        return error_redirect("/about", "Unable to send message. Please try again later.")
+
+    success = send_contact_email(
+        admin_emails=admin_emails,
+        sender_name=sender_name,
+        sender_email=sender_email,
+        subject_line=subject_line,
+        message=message,
+    )
+
+    if success:
+        return success_redirect("/about", "Your message has been sent! We'll get back to you soon.")
+    return error_redirect("/about", "Failed to send message. Please try again later.")
 
 
 @router.get("/{page:path}")

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
+{% from "macros.html" import csrf_token, alert, form_field %}
 {% block title %}About - South Austin Bass Club{% endblock %}
 {% block content %}
+{{ alert('success', request.query_params.get('success')) }}
+{{ alert('danger', request.query_params.get('error')) }}
 <div class="mb-4">
 <h1 class="display-5"><i class="bi bi-people-fill me-2"></i>About</h1>
 <p class="lead text-secondary">South Austin Bass Club - Established 1983</p>
@@ -61,6 +64,29 @@
 <p class="mb-3 text-dark">Send payments for tournament entry fees, buy-ins, and membership dues via Venmo:</p>
 <img src="/static/venmo.png" alt="Venmo QR Code - Chris Annoni @Chris-Annoni" class="img-fluid" style="max-width:200px">
 <p class="mt-3 text-dark"><strong>@Chris-Annoni</strong></p>
+</div>
+</div>
+</div>
+<!-- Contact Form -->
+<div class="col-12">
+<div class="card shadow-sm">
+<div class="card-header bg-secondary text-white"><h5 class="mb-0"><i class="bi bi-envelope-fill me-2"></i>Contact Us</h5></div>
+<div class="card-body">
+<p class="text-secondary mb-3">Have a question or want to learn more? Send us a message and we'll get back to you.</p>
+<form method="POST" action="/about/contact">
+    {{ csrf_token(request) }}
+    <div class="row">
+        <div class="col-md-6">
+            {{ form_field('Name', 'name', required=True, placeholder='Your name', maxlength='100') }}
+        </div>
+        <div class="col-md-6">
+            {{ form_field('Email', 'email', type='email', required=True, placeholder='your@email.com', maxlength='255') }}
+        </div>
+    </div>
+    {{ form_field('Subject', 'subject', required=True, placeholder='What is this about?', maxlength='200') }}
+    {{ form_field('Message', 'message', type='textarea', required=True, placeholder='Your message...', rows='5', maxlength='2000') }}
+    <button type="submit" class="btn btn-primary"><i class="bi bi-send me-2"></i>Send Message</button>
+</form>
 </div>
 </div>
 </div>

--- a/tests/integration/test_contact_form.py
+++ b/tests/integration/test_contact_form.py
@@ -1,0 +1,188 @@
+"""Contact form tests."""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from core.db_schema import Angler
+from tests.conftest import post_with_csrf
+
+
+class TestContactFormPage:
+    """Test the contact form is displayed on the about page."""
+
+    def test_about_page_shows_contact_form(self, client: TestClient):
+        """Test that the about page contains the contact form."""
+        response = client.get("/about")
+        assert response.status_code == 200
+        assert "Contact Us" in response.text
+        assert 'action="/about/contact"' in response.text
+        assert 'name="name"' in response.text
+        assert 'name="email"' in response.text
+        assert 'name="subject"' in response.text
+        assert 'name="message"' in response.text
+
+
+class TestContactFormSubmission:
+    """Test contact form submission logic."""
+
+    def test_contact_form_missing_fields(self, client: TestClient):
+        """Test that missing fields return an error."""
+        response = post_with_csrf(
+            client,
+            "/about/contact",
+            data={"name": "Test", "email": "", "subject": "", "message": ""},
+        )
+        assert response.status_code == 200  # After redirect
+        assert "error" in str(response.url) or "All fields are required" in response.text
+
+    def test_contact_form_success(
+        self, client: TestClient, db_session: Session, password_hash: str
+    ):
+        """Test successful contact form submission sends email to admins."""
+        # Create an admin user with a valid email
+        admin = Angler(
+            name="Admin User",
+            email="admin@example.com",
+            password_hash=password_hash,
+            member=True,
+            is_admin=True,
+        )
+        db_session.add(admin)
+        db_session.commit()
+
+        with patch("routes.pages.home.send_contact_email", return_value=True) as mock_send:
+            response = post_with_csrf(
+                client,
+                "/about/contact",
+                data={
+                    "name": "John Doe",
+                    "email": "john@example.com",
+                    "subject": "Question about membership",
+                    "message": "I would like to join the club.",
+                },
+            )
+            assert response.status_code == 200  # After redirect
+            mock_send.assert_called_once_with(
+                admin_emails=["admin@example.com"],
+                sender_name="John Doe",
+                sender_email="john@example.com",
+                subject_line="Question about membership",
+                message="I would like to join the club.",
+            )
+
+    def test_contact_form_excludes_placeholder_domains(
+        self, client: TestClient, db_session: Session, password_hash: str
+    ):
+        """Test that admin emails with placeholder domains are excluded."""
+        # Admin with placeholder domain - should be excluded
+        admin_placeholder = Angler(
+            name="Placeholder Admin",
+            email="admin@sabc.com",
+            password_hash=password_hash,
+            member=True,
+            is_admin=True,
+        )
+        # Admin with club domain - should be excluded
+        admin_club = Angler(
+            name="Club Admin",
+            email="admin@saustinbc.com",
+            password_hash=password_hash,
+            member=True,
+            is_admin=True,
+        )
+        # Admin with valid email - should be included
+        admin_valid = Angler(
+            name="Valid Admin",
+            email="valid@example.com",
+            password_hash=password_hash,
+            member=True,
+            is_admin=True,
+        )
+        db_session.add_all([admin_placeholder, admin_club, admin_valid])
+        db_session.commit()
+
+        with patch("routes.pages.home.send_contact_email", return_value=True) as mock_send:
+            response = post_with_csrf(
+                client,
+                "/about/contact",
+                data={
+                    "name": "Jane",
+                    "email": "jane@example.com",
+                    "subject": "Test",
+                    "message": "Hello",
+                },
+            )
+            assert response.status_code == 200
+            mock_send.assert_called_once()
+            call_args = mock_send.call_args
+            assert call_args.kwargs["admin_emails"] == ["valid@example.com"]
+
+    def test_contact_form_no_admins(self, client: TestClient, db_session: Session):
+        """Test contact form when no admin emails are available."""
+        # No admins in DB
+        response = post_with_csrf(
+            client,
+            "/about/contact",
+            data={
+                "name": "Test",
+                "email": "test@example.com",
+                "subject": "Test",
+                "message": "Hello",
+            },
+        )
+        assert response.status_code == 200
+        assert "error" in str(response.url) or "Unable to send" in response.text
+
+    def test_contact_form_email_failure(
+        self, client: TestClient, db_session: Session, password_hash: str
+    ):
+        """Test contact form when email sending fails."""
+        admin = Angler(
+            name="Admin",
+            email="admin@example.com",
+            password_hash=password_hash,
+            member=True,
+            is_admin=True,
+        )
+        db_session.add(admin)
+        db_session.commit()
+
+        with patch("routes.pages.home.send_contact_email", return_value=False):
+            response = post_with_csrf(
+                client,
+                "/about/contact",
+                data={
+                    "name": "Test",
+                    "email": "test@example.com",
+                    "subject": "Test",
+                    "message": "Hello",
+                },
+            )
+            assert response.status_code == 200
+            assert "error" in str(response.url) or "Failed to send" in response.text
+
+
+class TestContactEmailTemplate:
+    """Test the contact email template generation."""
+
+    def test_generate_contact_email_content(self):
+        """Test that email content is generated correctly."""
+        from core.email.templates import generate_contact_email_content
+
+        subject, text_body, html_body = generate_contact_email_content(
+            sender_name="John Doe",
+            sender_email="john@example.com",
+            subject_line="Membership inquiry",
+            message="I want to join!",
+        )
+
+        assert "Contact: Membership inquiry" in subject
+        assert "John Doe" in text_body
+        assert "john@example.com" in text_body
+        assert "I want to join!" in text_body
+        assert "John Doe" in html_body
+        assert "john@example.com" in html_body
+        assert "I want to join!" in html_body
+        assert "Reply-To" not in html_body  # Reply-To is a header, not in body


### PR DESCRIPTION
## Summary
- Adds a "Contact Us" form to the About page that sends emails to all club admins
- Excludes `@sabc.com` and `@saustinbc.com` placeholder domains from recipients (same as news emails)
- Sets `Reply-To` header to the sender's email so admins can reply directly
- No login required — publicly accessible contact form

## Changes
- **`core/email/templates.py`** — New `generate_contact_email_content()` for HTML + plaintext email
- **`core/email/service.py`** — New `send_contact_email()` with test mode support
- **`core/email/__init__.py`** — Export the new function
- **`routes/pages/home.py`** — `POST /about/contact` route handler with admin email query + domain exclusion
- **`templates/about.html`** — Contact Us card with name, email, subject, and message fields
- **`tests/integration/test_contact_form.py`** — Tests for form display, submission, domain exclusion, error handling

## Test plan
- [x] `format-code` passes
- [x] `check-code` passes (MyPy + Ruff clean)
- [x] `run-tests` passes (938 passed, 1 skipped)
- [ ] Manual test: submit form on About page, verify admins receive email
- [ ] Manual test: verify success/error alerts display correctly

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)