### PR TITLE
Fix mobile portrait layout for tournament results grids

### DIFF
--- a/static/style-v2.css
+++ b/static/style-v2.css
@@ -2450,6 +2450,8 @@ textarea.fi { resize: vertical; min-height: 100px; }
    ========================================== */
 .g2 { display: grid; grid-template-columns: 2fr 1fr; gap: 1.4rem; }
 .g2e { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.grid-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; }
+.grid-payouts { display: grid; grid-template-columns: repeat(5, 1fr); gap: 0.75rem; }
 
 /* ==========================================
    NEWS ITEMS (from mockup)
@@ -2554,6 +2556,13 @@ textarea.fi { resize: vertical; min-height: 100px; }
   .sg { grid-template-columns: repeat(2, 1fr); }
   .cal-grid { grid-template-columns: repeat(2, 1fr); }
   .photo-grid { grid-template-columns: repeat(2, 1fr); }
+  .grid-stats { grid-template-columns: repeat(2, 1fr); }
+  .grid-payouts { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 400px) {
+  .grid-stats { grid-template-columns: 1fr; }
+  .grid-payouts { grid-template-columns: 1fr; }
 }
 
 /* ==========================================

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/static/style-v2.css?v=7">
+    <link rel="stylesheet" href="/static/style-v2.css?v=8">
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
     {% block extra_css %}{% endblock %}
     <!-- Hide previously dismissed cancelled tournament alerts immediately to prevent flash -->

--- a/templates/tournament_results.html
+++ b/templates/tournament_results.html
@@ -55,7 +55,7 @@
         <div style="font-size:.88rem;font-weight:600;color:var(--brand)"><i class="bi bi-graph-up" style="margin-right:.35rem"></i>Tournament Statistics</div>
     </div>
     <div class="ci">
-        <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:.75rem">
+        <div class="grid-stats">
             <div style="text-align:center;padding:.65rem;background:var(--bg-elevated);border-radius:var(--r-md)">
                 <div style="font-size:1.2rem;font-weight:800;color:var(--t1)">{{ tournament_stats[0] }}</div>
                 <div style="font-size:.7rem;color:var(--t3)">Anglers</div>
@@ -109,7 +109,7 @@
         <div style="font-size:.88rem;font-weight:600;color:var(--ok)"><i class="bi bi-cash-stack" style="margin-right:.35rem"></i>Tournament Payouts</div>
     </div>
     <div class="ci">
-        <div style="display:grid;grid-template-columns:repeat(5,1fr);gap:.75rem">
+        <div class="grid-payouts">
             <div style="text-align:center;padding:.65rem;background:var(--bg-elevated);border-radius:var(--r-md)">
                 <div style="font-size:1.1rem;font-weight:800;color:var(--t1)">${{ "%.2f"|format(payouts.total_entry) }}</div>
                 <div style="font-size:.7rem;color:var(--t3)">Total Entries</div>


### PR DESCRIPTION
## Summary
- Replace hardcoded inline `grid-template-columns: repeat(4,1fr)` and `repeat(5,1fr)` styles on the tournament results page with responsive CSS classes (`grid-stats`, `grid-payouts`)
- Add media query breakpoints so grids wrap to 2 columns at 768px and 1 column at 400px
- Bump CSS cache-bust parameter from `?v=7` to `?v=8`

Closes #276

## Test plan
- [x] Load a tournament results page on a mobile device in portrait orientation
- [x] Verify all 8 statistics tiles (Anglers, Total Fish, Total Weight, Limits, Zeros, Buy-ins, Big Bass, Heavy Stringer) are visible without horizontal scrolling
- [x] Verify all 5 payout tiles (Total Entries, 1st Place, 2nd Place, 3rd Place, Big Bass Pot) are visible without horizontal scrolling
- [x] Confirm layout wraps to 2 columns around 768px and 1 column around 400px
- [x] Verify desktop layout (>768px) is unchanged (4-column stats, 5-column payouts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)