### PR TITLE
Fix alert close button vertical alignment

### DIFF
--- a/static/style-v2.css
+++ b/static/style-v2.css
@@ -35,7 +35,7 @@
 
 /* Alert dismiss */
 .alert-dismissible { position: relative; padding-right: 3rem; }
-.alert-dismissible .btn-close { position: absolute; top: 0; right: 0; z-index: 2; padding: 1rem; }
+.alert-dismissible .btn-close { position: absolute; top: 50%; right: 0; transform: translateY(-50%); z-index: 2; padding: 1rem; }
 
 /* Close button */
 .btn-close { box-sizing: content-box; width: 1em; height: 1em; padding: 0.25em; background: transparent url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%2394a3b8'%3e%3cpath d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414z'/%3e%3c/svg%3e") center/1em auto no-repeat; border: 0; border-radius: 0.375rem; opacity: 0.75; cursor: pointer; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/static/style-v2.css?v=7">
+    <link rel="stylesheet" href="/static/style-v2.css?v=8">
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
     {% block extra_css %}{% endblock %}
     <!-- Hide previously dismissed cancelled tournament alerts immediately to prevent flash -->


### PR DESCRIPTION
## Summary
- Center the `.btn-close` X button vertically within `.alert-dismissible` banners using `top: 50%; transform: translateY(-50%)` instead of `top: 0`
- Bump CSS cache-bust parameter from `?v=7` to `?v=8` in `base.html`

Closes #277

## Test plan
- [ ] Verify alert banners display with the X button vertically centered
- [ ] Confirm alerts still dismiss correctly when clicking the X
- [ ] Check alignment on both desktop and mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)