### PR TITLE
Fix Turnstile CAPTCHA false positive on contact form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,21 @@ PORT=8000
 # RELEASE_VERSION=v1.0.0
 
 # ============================================================================
+# Cloudflare Turnstile CAPTCHA (Optional - contact form)
+# ============================================================================
+
+# Protects the contact form from bots.
+# Leave blank to disable (dev mode - form works without CAPTCHA).
+# Get keys at: https://dash.cloudflare.com/?to=/:account/turnstile
+#
+# For local testing, use Cloudflare's test keys:
+#   TURNSTILE_SITE_KEY=1x00000000000000000000AA    (always passes)
+#   TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA  (always passes)
+# See: https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=
+
+# ============================================================================
 # Optional: Advanced Settings
 # ============================================================================
 

--- a/routes/pages/home.py
+++ b/routes/pages/home.py
@@ -519,8 +519,13 @@ async def contact_form(request: Request) -> RedirectResponse:
         return success_redirect("/about", "Your message has been sent! We'll get back to you soon.")
 
     # Cloudflare Turnstile CAPTCHA verification
+    # When the site key is configured, the widget was shown to the user,
+    # so we must require a valid token (fail closed).
+    turnstile_token = str(form.get("cf-turnstile-response", "")).strip()
+    if TURNSTILE_SITE_KEY and not turnstile_token:
+        logger.warning(f"Turnstile token missing (from {sender_email})")
+        return error_redirect("/about", "CAPTCHA verification failed. Please try again.")
     if TURNSTILE_SECRET_KEY:
-        turnstile_token = str(form.get("cf-turnstile-response", "")).strip()
         client_ip = request.client.host if request.client else None
         if not await _verify_turnstile(turnstile_token, client_ip):
             logger.warning(f"Turnstile verification failed (from {sender_email})")

--- a/templates/about.html
+++ b/templates/about.html
@@ -69,10 +69,38 @@
             {% if turnstile_site_key %}
             <div class="fg">
                 <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-                <div class="cf-turnstile" data-sitekey="{{ turnstile_site_key }}" data-theme="dark"></div>
+                <div class="cf-turnstile" data-sitekey="{{ turnstile_site_key }}" data-theme="dark" data-callback="onTurnstileSuccess" data-expired-callback="onTurnstileExpired" data-error-callback="onTurnstileError"></div>
+                <div id="turnstile-msg" style="color:var(--err);font-size:.82rem;margin-top:.35rem;display:none">Please complete the CAPTCHA verification above.</div>
             </div>
             {% endif %}
-            <button class="btn-m btn-p" type="submit"><i class="bi bi-send" aria-hidden="true"></i> Send Message</button>
+            <button class="btn-m btn-p" type="submit" id="contact-submit"{% if turnstile_site_key %} disabled style="opacity:.5;cursor:not-allowed"{% endif %}><i class="bi bi-send" aria-hidden="true"></i> Send Message</button>
+            {% if turnstile_site_key %}
+            <script>
+            function onTurnstileSuccess(token) {
+                var btn = document.getElementById('contact-submit');
+                btn.disabled = false;
+                btn.style.opacity = '';
+                btn.style.cursor = '';
+                document.getElementById('turnstile-msg').style.display = 'none';
+            }
+            function onTurnstileExpired() {
+                var btn = document.getElementById('contact-submit');
+                btn.disabled = true;
+                btn.style.opacity = '.5';
+                btn.style.cursor = 'not-allowed';
+            }
+            function onTurnstileError() {
+                onTurnstileExpired();
+            }
+            document.querySelector('form[action="/about/contact"]').addEventListener('submit', function(e) {
+                var resp = document.querySelector('input[name="cf-turnstile-response"]');
+                if (!resp || !resp.value) {
+                    e.preventDefault();
+                    document.getElementById('turnstile-msg').style.display = 'block';
+                }
+            });
+            </script>
+            {% endif %}
         </form>
     </div>
 </div>

--- a/tests/integration/test_contact_form.py
+++ b/tests/integration/test_contact_form.py
@@ -404,6 +404,67 @@ class TestTurnstileVerification:
             assert response.status_code == 200
             mock_send.assert_called_once()
 
+    def test_turnstile_rejects_missing_token_when_site_key_configured(
+        self, client: TestClient, db_session: Session, password_hash: str
+    ):
+        """Test that missing Turnstile token is rejected when site key is set.
+
+        This is the core fix for issue #278: when the Turnstile widget is
+        displayed (TURNSTILE_SITE_KEY is set), submitting without completing
+        the CAPTCHA must fail -- even if the secret key is not configured.
+        """
+        admin = Angler(
+            name="Admin",
+            email="admin@example.com",
+            password_hash=password_hash,
+            member=True,
+            is_admin=True,
+        )
+        db_session.add(admin)
+        db_session.commit()
+
+        with (
+            patch("routes.pages.home.TURNSTILE_SITE_KEY", "test-site-key"),
+            patch("routes.pages.home.TURNSTILE_SECRET_KEY", ""),
+            patch("routes.pages.home.send_contact_email") as mock_send,
+        ):
+            response = post_with_csrf(
+                client,
+                "/about/contact",
+                data=_valid_form_data(),  # no cf-turnstile-response field
+            )
+            assert response.status_code == 200
+            assert "error" in str(response.url) or "CAPTCHA" in response.text
+            mock_send.assert_not_called()
+
+    def test_turnstile_rejects_empty_token_when_site_key_configured(
+        self, client: TestClient, db_session: Session, password_hash: str
+    ):
+        """Test that an empty Turnstile token is rejected when site key is set."""
+        admin = Angler(
+            name="Admin",
+            email="admin@example.com",
+            password_hash=password_hash,
+            member=True,
+            is_admin=True,
+        )
+        db_session.add(admin)
+        db_session.commit()
+
+        with (
+            patch("routes.pages.home.TURNSTILE_SITE_KEY", "test-site-key"),
+            patch("routes.pages.home.TURNSTILE_SECRET_KEY", "test-secret-key"),
+            patch("routes.pages.home.send_contact_email") as mock_send,
+        ):
+            response = post_with_csrf(
+                client,
+                "/about/contact",
+                data={**_valid_form_data(), "cf-turnstile-response": ""},
+            )
+            assert response.status_code == 200
+            assert "error" in str(response.url) or "CAPTCHA" in response.text
+            mock_send.assert_not_called()
+
     def test_turnstile_widget_shown_when_configured(self, client: TestClient):
         """Test that Turnstile widget appears when site key is set."""
         with patch("routes.pages.home.TURNSTILE_SITE_KEY", "test-site-key"):


### PR DESCRIPTION
## Summary
- **Client-side**: Disable submit button until Turnstile challenge is completed; show error message if user tries to bypass it via `data-callback`/`data-expired-callback`/`data-error-callback` attributes and a form submit listener
- **Server-side**: Fail closed when `TURNSTILE_SITE_KEY` is set but the token is missing or empty, returning an error redirect instead of silently proceeding
- **`.env.example`**: Document `TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` with Cloudflare's test keys for local development
- **Tests**: Add two new integration tests covering missing and empty token rejection when Turnstile is configured

Closes #278

## Test plan
- [ ] Verify existing contact form tests still pass (956 passed, 1 skipped)
- [ ] With `TURNSTILE_SITE_KEY` set and no secret key, confirm form submission without completing CAPTCHA returns error
- [ ] With both keys set, confirm empty `cf-turnstile-response` returns error
- [ ] With both keys set and valid token, confirm form submits successfully
- [ ] With neither key set (dev mode), confirm form works without CAPTCHA
- [ ] Verify submit button is disabled until Turnstile widget is completed in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)