### PR TITLE
Add sunrise & weather forecast to tournament polls

### DIFF
--- a/core/helpers/poll_day_info.py
+++ b/core/helpers/poll_day_info.py
@@ -1,0 +1,130 @@
+"""Sunrise + weather forecast for tournament poll days.
+
+Sunrise is computed locally with `astral` (no API). Weather is pulled from the
+National Weather Service public API and cached in-memory for 30 minutes.
+"""
+
+from datetime import date as date_cls
+from datetime import datetime, time, timedelta, timezone
+from typing import Any, Dict, List, Optional
+from zoneinfo import ZoneInfo
+
+import httpx
+from astral import LocationInfo
+from astral.sun import sun
+
+from core.helpers.logging import get_logger
+
+logger = get_logger(__name__)
+
+AUSTIN_LAT = 30.2672
+AUSTIN_LON = -97.7431
+AUSTIN_TZ = ZoneInfo("America/Chicago")
+NWS_USER_AGENT = "SABC-Tournament-App (https://github.com/envasquez/SABC)"
+NWS_BASE = "https://api.weather.gov"
+FORECAST_TTL = timedelta(minutes=30)
+HTTP_TIMEOUT = 5.0
+
+_austin_location = LocationInfo("Austin", "USA", "America/Chicago", AUSTIN_LAT, AUSTIN_LON)
+
+_forecast_cache: Dict[str, Any] = {"periods": None, "fetched_at": None}
+_forecast_url_cache: Optional[str] = None
+
+
+def get_sunrise(target_date: date_cls) -> time:
+    s = sun(_austin_location.observer, date=target_date, tzinfo=AUSTIN_TZ)
+    return s["sunrise"].astimezone(AUSTIN_TZ).time()
+
+
+def _get_forecast_url(client: httpx.Client) -> str:
+    global _forecast_url_cache
+    if _forecast_url_cache is not None:
+        return _forecast_url_cache
+    resp = client.get(f"{NWS_BASE}/points/{AUSTIN_LAT},{AUSTIN_LON}", timeout=HTTP_TIMEOUT)
+    resp.raise_for_status()
+    url: str = resp.json()["properties"]["forecast"]
+    _forecast_url_cache = url
+    return url
+
+
+def _fetch_forecast_periods() -> Optional[List[Dict[str, Any]]]:
+    now = datetime.now(timezone.utc)
+    fetched_at = _forecast_cache.get("fetched_at")
+    if fetched_at and now - fetched_at < FORECAST_TTL:
+        cached: Optional[List[Dict[str, Any]]] = _forecast_cache.get("periods")
+        return cached
+
+    headers = {"User-Agent": NWS_USER_AGENT, "Accept": "application/geo+json"}
+    try:
+        with httpx.Client(headers=headers) as client:
+            forecast_url = _get_forecast_url(client)
+            resp = client.get(forecast_url, timeout=HTTP_TIMEOUT)
+            resp.raise_for_status()
+            periods = resp.json()["properties"]["periods"]
+    except (httpx.HTTPError, KeyError, ValueError) as e:
+        logger.warning(f"NWS forecast fetch failed: {e}")
+        # Serve stale cache on failure if we have any, else None.
+        stale: Optional[List[Dict[str, Any]]] = _forecast_cache.get("periods")
+        return stale
+
+    _forecast_cache["periods"] = periods
+    _forecast_cache["fetched_at"] = now
+    return periods
+
+
+def _summarize_periods_for_date(
+    periods: List[Dict[str, Any]], target_date: date_cls
+) -> Optional[Dict[str, Any]]:
+    day_period: Optional[Dict[str, Any]] = None
+    night_period: Optional[Dict[str, Any]] = None
+    for p in periods:
+        try:
+            start_local = datetime.fromisoformat(p["startTime"]).astimezone(AUSTIN_TZ).date()
+        except (KeyError, ValueError):
+            continue
+        if start_local != target_date:
+            continue
+        if p.get("isDaytime"):
+            day_period = p
+        else:
+            night_period = p
+
+    if day_period is None and night_period is None:
+        return None
+
+    primary = day_period or night_period
+    assert primary is not None
+    precip = (primary.get("probabilityOfPrecipitation") or {}).get("value")
+    return {
+        "high": day_period["temperature"] if day_period else None,
+        "low": night_period["temperature"] if night_period else None,
+        "unit": primary.get("temperatureUnit", "F"),
+        "short_forecast": primary.get("shortForecast"),
+        "detailed_forecast": primary.get("detailedForecast"),
+        "precip_chance": precip,
+        "icon": primary.get("icon"),
+    }
+
+
+def get_weather(target_date: date_cls) -> Optional[Dict[str, Any]]:
+    """Returns forecast summary for `target_date`, or None if outside the window
+    or NWS is unreachable."""
+    periods = _fetch_forecast_periods()
+    if not periods:
+        return None
+    return _summarize_periods_for_date(periods, target_date)
+
+
+def get_poll_day_info(target_date: date_cls) -> Dict[str, Any]:
+    return {
+        "date": target_date,
+        "sunrise": get_sunrise(target_date),
+        "weather": get_weather(target_date),
+    }
+
+
+def _reset_caches_for_test() -> None:
+    global _forecast_url_cache
+    _forecast_url_cache = None
+    _forecast_cache["periods"] = None
+    _forecast_cache["fetched_at"] = None

--- a/flake.nix
+++ b/flake.nix
@@ -212,8 +212,8 @@ print('Database reset complete!')
           ];
 
           shellHook = ''
-            # Note: slowapi and starlette-csrf should be installed manually to .nix-python-packages
-            # Run: python3.12 -m pip install --target .nix-python-packages starlette-csrf==3.0.0 slowapi==0.1.9
+            # Note: slowapi, starlette-csrf, and astral should be installed manually to .nix-python-packages
+            # Run: python3.12 -m pip install --target .nix-python-packages starlette-csrf==3.0.0 slowapi==0.1.9 astral==3.2
 
             echo "🎣 SABC FastAPI Development Environment"
             echo "======================================"

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,6 +1,7 @@
 aiosqlite==0.20.0
 annotated-types==0.7.0
 anyio==4.11.0
+astral==3.2
 attrs==25.3.0
 bcrypt==4.2.1
 beautifulsoup4==4.13.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ urllib3==2.6.3
 requests==2.33.0
 cryptography==46.0.7
 Pillow==12.2.0
+astral==3.2

--- a/routes/voting/list_polls.py
+++ b/routes/voting/list_polls.py
@@ -4,9 +4,11 @@ from fastapi import APIRouter, BackgroundTasks, Depends, Request
 from fastapi.responses import RedirectResponse
 from sqlalchemy import case, exists, false, func, select, true
 
-from core.db_schema import Angler, Poll, PollVote, engine, get_session
+from core.db_schema import Angler, Event, Poll, PollVote, engine, get_session
 from core.deps import templates
 from core.helpers.auth import is_dues_current, require_auth
+from core.helpers.logging import get_logger
+from core.helpers.poll_day_info import get_poll_day_info
 from core.helpers.timezone import now_local
 from core.query_service import QueryService
 from core.types import UserDict
@@ -17,6 +19,7 @@ from routes.voting.helpers import (
     process_closed_polls,
 )
 
+logger = get_logger(__name__)
 router = APIRouter()
 
 
@@ -198,12 +201,21 @@ async def polls(
             # Get vote count from pre-fetched data
             unique_voters = vote_counts.get(poll_row.id, 0)
 
-            # Get seasonal history for tournament polls
+            # Get seasonal history + day-of info (sunrise/weather) for tournament polls
             seasonal_history = []
+            day_info: Optional[Dict[str, Any]] = None
             if poll_row.poll_type == "tournament_location":
                 poll_obj = session.query(Poll).filter(Poll.id == poll_row.id).first()
                 if poll_obj:
                     seasonal_history = get_seasonal_tournament_history(session, poll_obj)
+                    if poll_obj.event_id:
+                        event = session.query(Event).filter(Event.id == poll_obj.event_id).first()
+                        if event and event.date:
+                            try:
+                                day_info = get_poll_day_info(event.date)
+                            except Exception as e:
+                                # Never let sunrise/weather lookup break the poll page.
+                                logger.warning(f"poll_day_info failed for poll {poll_row.id}: {e}")
 
             polls.append(
                 {
@@ -224,6 +236,7 @@ async def polls(
                         (unique_voters / member_count * 100) if member_count > 0 else 0, 1
                     ),
                     "seasonal_history": seasonal_history,
+                    "day_info": day_info,
                 }
             )
 

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -291,52 +291,29 @@
 </div>
 {% endmacro %}
 
-{# Day-of info card: sunrise + weather forecast for the tournament date #}
+{# Day-of info strip: sunrise + weather forecast for the tournament date.
+   Compact single-line layout meant to sit at the top of a tournament poll. #}
 {% macro poll_day_info_card(day_info) %}
 {% if day_info %}
-<div class="cc" style="margin-top:1rem">
-    <div style="padding:.6rem .8rem;border-bottom:1px solid var(--b0)">
-        <div style="font-size:.82rem;font-weight:600;color:var(--info)">
-            <i class="bi bi-cloud-sun" style="margin-right:.25rem"></i>
-            Tournament Day Conditions{% if day_info.date %} <span style="color:var(--t4);font-weight:400">({{ day_info.date.strftime('%a %b %d') }})</span>{% endif %}
-        </div>
-    </div>
-    <div class="ci">
-        <div style="display:grid;grid-template-columns:repeat({% if day_info.weather %}3{% else %}1{% endif %},1fr);gap:.75rem">
-            <div style="text-align:center">
-                <i class="bi bi-sunrise" style="color:var(--warn);font-size:1.4rem;display:block;margin-bottom:.2rem"></i>
-                <div style="font-size:.72rem;color:var(--t3)">Sunrise (Austin)</div>
-                <div style="font-weight:700;font-size:.95rem">{{ day_info.sunrise.strftime('%-I:%M %p') }}</div>
-            </div>
-            {% if day_info.weather %}
-            <div style="text-align:center">
-                <i class="bi bi-thermometer-half" style="color:var(--err);font-size:1.4rem;display:block;margin-bottom:.2rem"></i>
-                <div style="font-size:.72rem;color:var(--t3)">High / Low</div>
-                <div style="font-weight:700;font-size:.95rem">
-                    {% if day_info.weather.high is not none %}{{ day_info.weather.high }}°{{ day_info.weather.unit }}{% else %}—{% endif %}
-                    /
-                    {% if day_info.weather.low is not none %}{{ day_info.weather.low }}°{{ day_info.weather.unit }}{% else %}—{% endif %}
-                </div>
-            </div>
-            <div style="text-align:center">
-                <i class="bi bi-cloud-drizzle" style="color:var(--info);font-size:1.4rem;display:block;margin-bottom:.2rem"></i>
-                <div style="font-size:.72rem;color:var(--t3)">Conditions</div>
-                <div style="font-weight:700;font-size:.88rem">
-                    {{ day_info.weather.short_forecast or '—' }}
-                    {% if day_info.weather.precip_chance %}
-                        <span style="color:var(--info);font-weight:600">({{ day_info.weather.precip_chance }}%)</span>
-                    {% endif %}
-                </div>
-            </div>
-            {% endif %}
-        </div>
-        {% if not day_info.weather %}
-        <div style="font-size:.72rem;color:var(--t4);margin-top:.5rem;text-align:center">
-            <i class="bi bi-info-circle"></i>
-            Weather forecast available within ~7 days of tournament
-        </div>
-        {% endif %}
-    </div>
+<div style="display:flex;flex-wrap:wrap;align-items:center;gap:.6rem .9rem;padding:.4rem .65rem;margin-bottom:.75rem;border-left:3px solid var(--info);background:var(--bg-elevated);border-radius:var(--r-sm);font-size:.78rem;color:var(--t2)" title="Conditions for the tournament date in Austin, TX">
+    {% if day_info.date %}
+    <span style="color:var(--t4);font-weight:600">{{ day_info.date.strftime('%a %b %-d') }}</span>
+    {% endif %}
+    <span><i class="bi bi-sunrise" style="color:var(--warn);margin-right:.25rem"></i><strong>{{ day_info.sunrise.strftime('%-I:%M %p') }}</strong> sunrise</span>
+    {% if day_info.weather %}
+    <span style="color:var(--t4)">·</span>
+    <span>
+        <i class="bi bi-thermometer-half" style="color:var(--err);margin-right:.2rem"></i>
+        <strong>{% if day_info.weather.high is not none %}{{ day_info.weather.high }}°{% else %}—{% endif %}</strong>/<strong>{% if day_info.weather.low is not none %}{{ day_info.weather.low }}°{% else %}—{% endif %}</strong>{{ day_info.weather.unit }}
+    </span>
+    <span style="color:var(--t4)">·</span>
+    <span>
+        <i class="bi bi-cloud-sun" style="color:var(--info);margin-right:.2rem"></i>
+        {{ day_info.weather.short_forecast or '—' }}{% if day_info.weather.precip_chance %} <span style="color:var(--info);font-weight:600">({{ day_info.weather.precip_chance }}% rain)</span>{% endif %}
+    </span>
+    {% else %}
+    <span style="color:var(--t4)">· weather available ~7 days out</span>
+    {% endif %}
 </div>
 {% endif %}
 {% endmacro %}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -291,6 +291,56 @@
 </div>
 {% endmacro %}
 
+{# Day-of info card: sunrise + weather forecast for the tournament date #}
+{% macro poll_day_info_card(day_info) %}
+{% if day_info %}
+<div class="cc" style="margin-top:1rem">
+    <div style="padding:.6rem .8rem;border-bottom:1px solid var(--b0)">
+        <div style="font-size:.82rem;font-weight:600;color:var(--info)">
+            <i class="bi bi-cloud-sun" style="margin-right:.25rem"></i>
+            Tournament Day Conditions{% if day_info.date %} <span style="color:var(--t4);font-weight:400">({{ day_info.date.strftime('%a %b %d') }})</span>{% endif %}
+        </div>
+    </div>
+    <div class="ci">
+        <div style="display:grid;grid-template-columns:repeat({% if day_info.weather %}3{% else %}1{% endif %},1fr);gap:.75rem">
+            <div style="text-align:center">
+                <i class="bi bi-sunrise" style="color:var(--warn);font-size:1.4rem;display:block;margin-bottom:.2rem"></i>
+                <div style="font-size:.72rem;color:var(--t3)">Sunrise (Austin)</div>
+                <div style="font-weight:700;font-size:.95rem">{{ day_info.sunrise.strftime('%-I:%M %p') }}</div>
+            </div>
+            {% if day_info.weather %}
+            <div style="text-align:center">
+                <i class="bi bi-thermometer-half" style="color:var(--err);font-size:1.4rem;display:block;margin-bottom:.2rem"></i>
+                <div style="font-size:.72rem;color:var(--t3)">High / Low</div>
+                <div style="font-weight:700;font-size:.95rem">
+                    {% if day_info.weather.high is not none %}{{ day_info.weather.high }}°{{ day_info.weather.unit }}{% else %}—{% endif %}
+                    /
+                    {% if day_info.weather.low is not none %}{{ day_info.weather.low }}°{{ day_info.weather.unit }}{% else %}—{% endif %}
+                </div>
+            </div>
+            <div style="text-align:center">
+                <i class="bi bi-cloud-drizzle" style="color:var(--info);font-size:1.4rem;display:block;margin-bottom:.2rem"></i>
+                <div style="font-size:.72rem;color:var(--t3)">Conditions</div>
+                <div style="font-weight:700;font-size:.88rem">
+                    {{ day_info.weather.short_forecast or '—' }}
+                    {% if day_info.weather.precip_chance %}
+                        <span style="color:var(--info);font-weight:600">({{ day_info.weather.precip_chance }}%)</span>
+                    {% endif %}
+                </div>
+            </div>
+            {% endif %}
+        </div>
+        {% if not day_info.weather %}
+        <div style="font-size:.72rem;color:var(--t4);margin-top:.5rem;text-align:center">
+            <i class="bi bi-info-circle"></i>
+            Weather forecast available within ~7 days of tournament
+        </div>
+        {% endif %}
+    </div>
+</div>
+{% endif %}
+{% endmacro %}
+
 {# Seasonal tournament history card macro - detailed version #}
 {% macro seasonal_history_card(seasonal_history) %}
 {% if seasonal_history and seasonal_history|length > 0 %}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -292,27 +292,24 @@
 {% endmacro %}
 
 {# Day-of info strip: sunrise + weather forecast for the tournament date.
-   Compact single-line layout meant to sit at the top of a tournament poll. #}
+   Designed to sit inline on the poll's header row (next to the title/badges). #}
 {% macro poll_day_info_card(day_info) %}
 {% if day_info %}
-<div style="display:flex;flex-wrap:wrap;align-items:center;gap:.6rem .9rem;padding:.4rem .65rem;margin-bottom:.75rem;border-left:3px solid var(--info);background:var(--bg-elevated);border-radius:var(--r-sm);font-size:.78rem;color:var(--t2)" title="Conditions for the tournament date in Austin, TX">
-    {% if day_info.date %}
-    <span style="color:var(--t4);font-weight:600">{{ day_info.date.strftime('%a %b %-d') }}</span>
-    {% endif %}
-    <span><i class="bi bi-sunrise" style="color:var(--warn);margin-right:.25rem"></i><strong>{{ day_info.sunrise.strftime('%-I:%M %p') }}</strong> sunrise</span>
+<div style="display:flex;flex-wrap:wrap;align-items:center;gap:.4rem .8rem;font-size:.75rem;color:var(--t2);line-height:1.4" title="Conditions for the tournament date in Austin, TX">
+    <span>Expected Sunrise <i class="bi bi-sunrise" style="color:var(--warn);margin:0 .2rem"></i><strong>{{ day_info.sunrise.strftime('%-I:%M %p') }}</strong></span>
     {% if day_info.weather %}
     <span style="color:var(--t4)">·</span>
     <span>
-        <i class="bi bi-thermometer-half" style="color:var(--err);margin-right:.2rem"></i>
+        <i class="bi bi-thermometer-half" style="color:var(--err);margin-right:.15rem"></i>
         <strong>{% if day_info.weather.high is not none %}{{ day_info.weather.high }}°{% else %}—{% endif %}</strong>/<strong>{% if day_info.weather.low is not none %}{{ day_info.weather.low }}°{% else %}—{% endif %}</strong>{{ day_info.weather.unit }}
     </span>
     <span style="color:var(--t4)">·</span>
     <span>
-        <i class="bi bi-cloud-sun" style="color:var(--info);margin-right:.2rem"></i>
-        {{ day_info.weather.short_forecast or '—' }}{% if day_info.weather.precip_chance %} <span style="color:var(--info);font-weight:600">({{ day_info.weather.precip_chance }}% rain)</span>{% endif %}
+        <i class="bi bi-cloud-sun" style="color:var(--info);margin-right:.15rem"></i>
+        {{ day_info.weather.short_forecast or '—' }}{% if day_info.weather.precip_chance %} <span style="color:var(--info);font-weight:600">({{ day_info.weather.precip_chance }}%)</span>{% endif %}
     </span>
     {% else %}
-    <span style="color:var(--t4)">· weather available ~7 days out</span>
+    <span style="color:var(--t4)">· weather ~7d out</span>
     {% endif %}
 </div>
 {% endif %}

--- a/templates/polls.html
+++ b/templates/polls.html
@@ -39,8 +39,8 @@
     {% for poll in polls %}
     <div class="cc" style="margin-bottom:1.4rem" id="poll-{{ poll.id }}">
         <!-- Poll Header -->
-        <div style="padding:.8rem 1.2rem;border-bottom:1px solid var(--b0);display:flex;justify-content:space-between;align-items:center">
-            <div>
+        <div style="padding:.8rem 1.2rem;border-bottom:1px solid var(--b0);display:flex;flex-wrap:wrap;justify-content:space-between;align-items:center;gap:.75rem">
+            <div style="flex:0 1 auto">
                 <div style="font-weight:700;font-size:.95rem;color:var(--t1)">
                     {{ poll.title }}
                     {% if poll.status == 'closed' %}
@@ -55,8 +55,16 @@
                     Opens {{ (poll.starts_at | to_local).strftime('%m-%d-%Y at %H:%M') }} | Closes {{ (poll.closes_at | to_local).strftime('%m-%d-%Y at %H:%M') }}
                 </div>
             </div>
+
+            <!-- Day-of info: sunrise + weather forecast (tournament polls only) -->
+            {% if poll.poll_type == 'tournament_location' and poll.day_info and poll.status == 'active' %}
+            <div style="flex:1 1 auto;display:flex;justify-content:flex-end;min-width:0">
+                {{ poll_day_info_card(poll.day_info) }}
+            </div>
+            {% endif %}
+
             {% if user and user.is_admin %}
-            <div style="display:flex;gap:.25rem">
+            <div style="display:flex;gap:.25rem;flex:0 0 auto">
                 <button class="btn-icon btn-icon-ghost"
                         onclick="window.location.href='/admin/polls/{{ poll.id }}/edit'"
                         aria-label="Edit poll">
@@ -77,11 +85,6 @@
             <div style="margin-bottom:.75rem">
                 <p style="color:var(--t3);margin:0">{{ poll.description | nl2br }}</p>
             </div>
-            {% endif %}
-
-            <!-- Day-of info: sunrise + weather forecast (tournament polls only) -->
-            {% if poll.poll_type == 'tournament_location' and poll.day_info and poll.status == 'active' %}
-                {{ poll_day_info_card(poll.day_info) }}
             {% endif %}
 
             {% if poll.options %}

--- a/templates/polls.html
+++ b/templates/polls.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'macros.html' import alert, badge, csrf_token, delete_modal, time_select_options, seasonal_history_card %}
+{% from 'macros.html' import alert, badge, csrf_token, delete_modal, time_select_options, seasonal_history_card, poll_day_info_card %}
 
 {% block title %}Polls - South Austin Bass Club{% endblock %}
 
@@ -210,6 +210,11 @@
                             <i class="bi bi-check-square" style="margin-right:.35rem"></i>Cast Your Vote
                         </button>
                     </form>
+
+                    <!-- Day-of info: sunrise + weather forecast -->
+                    {% if poll.poll_type == 'tournament_location' and poll.day_info %}
+                        {{ poll_day_info_card(poll.day_info) }}
+                    {% endif %}
 
                     <!-- Seasonal Tournament History for active tournament polls -->
                     {% if poll.poll_type == 'tournament_location' and poll.seasonal_history and poll.seasonal_history|length > 0 %}

--- a/templates/polls.html
+++ b/templates/polls.html
@@ -79,6 +79,11 @@
             </div>
             {% endif %}
 
+            <!-- Day-of info: sunrise + weather forecast (tournament polls only) -->
+            {% if poll.poll_type == 'tournament_location' and poll.day_info and poll.status == 'active' %}
+                {{ poll_day_info_card(poll.day_info) }}
+            {% endif %}
+
             {% if poll.options %}
                 <!-- Per-Poll Tabs for Admin Proxy Voting -->
                 {% if user.is_admin and poll.status == 'active' %}
@@ -210,11 +215,6 @@
                             <i class="bi bi-check-square" style="margin-right:.35rem"></i>Cast Your Vote
                         </button>
                     </form>
-
-                    <!-- Day-of info: sunrise + weather forecast -->
-                    {% if poll.poll_type == 'tournament_location' and poll.day_info %}
-                        {{ poll_day_info_card(poll.day_info) }}
-                    {% endif %}
 
                     <!-- Seasonal Tournament History for active tournament polls -->
                     {% if poll.poll_type == 'tournament_location' and poll.seasonal_history and poll.seasonal_history|length > 0 %}

--- a/tests/unit/test_poll_day_info.py
+++ b/tests/unit/test_poll_day_info.py
@@ -1,0 +1,251 @@
+"""Unit tests for core/helpers/poll_day_info.py."""
+
+from datetime import date, datetime, time
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from core.helpers import poll_day_info
+from core.helpers.poll_day_info import (
+    AUSTIN_TZ,
+    _summarize_periods_for_date,
+    get_poll_day_info,
+    get_sunrise,
+    get_weather,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_caches():
+    poll_day_info._reset_caches_for_test()
+    yield
+    poll_day_info._reset_caches_for_test()
+
+
+class TestSunrise:
+    def test_sunrise_returns_time_object(self):
+        result = get_sunrise(date(2026, 6, 21))
+        assert isinstance(result, time)
+
+    def test_sunrise_summer_solstice_austin_around_630_am(self):
+        # Austin sunrise on summer solstice is ~6:30 AM local time.
+        result = get_sunrise(date(2026, 6, 21))
+        assert 6 <= result.hour <= 7
+
+    def test_sunrise_winter_solstice_austin_around_730_am(self):
+        # Austin sunrise on winter solstice is ~7:20 AM local time.
+        result = get_sunrise(date(2026, 12, 21))
+        assert 7 <= result.hour <= 8
+
+    def test_sunrise_is_deterministic(self):
+        a = get_sunrise(date(2026, 4, 15))
+        b = get_sunrise(date(2026, 4, 15))
+        assert a == b
+
+
+def _make_period(start: datetime, is_daytime: bool, **overrides):
+    base = {
+        "startTime": start.isoformat(),
+        "isDaytime": is_daytime,
+        "temperature": 78 if is_daytime else 62,
+        "temperatureUnit": "F",
+        "shortForecast": "Sunny" if is_daytime else "Clear",
+        "detailedForecast": "Lots of sun.",
+        "probabilityOfPrecipitation": {"value": 10},
+        "icon": "https://example.com/icon.png",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSummarizePeriodsForDate:
+    def test_returns_none_when_no_match(self):
+        target = date(2026, 5, 10)
+        periods = [
+            _make_period(datetime(2026, 5, 1, 6, tzinfo=AUSTIN_TZ), True),
+        ]
+        assert _summarize_periods_for_date(periods, target) is None
+
+    def test_pairs_day_and_night_for_target_date(self):
+        target = date(2026, 5, 10)
+        periods = [
+            _make_period(
+                datetime(2026, 5, 10, 6, tzinfo=AUSTIN_TZ),
+                True,
+                temperature=85,
+                shortForecast="Mostly Sunny",
+                probabilityOfPrecipitation={"value": 20},
+            ),
+            _make_period(
+                datetime(2026, 5, 10, 19, tzinfo=AUSTIN_TZ),
+                False,
+                temperature=64,
+            ),
+        ]
+        result = _summarize_periods_for_date(periods, target)
+        assert result == {
+            "high": 85,
+            "low": 64,
+            "unit": "F",
+            "short_forecast": "Mostly Sunny",
+            "detailed_forecast": "Lots of sun.",
+            "precip_chance": 20,
+            "icon": "https://example.com/icon.png",
+        }
+
+    def test_handles_only_night_period(self):
+        target = date(2026, 5, 10)
+        periods = [
+            _make_period(datetime(2026, 5, 10, 19, tzinfo=AUSTIN_TZ), False, temperature=58),
+        ]
+        result = _summarize_periods_for_date(periods, target)
+        assert result is not None
+        assert result["high"] is None
+        assert result["low"] == 58
+
+    def test_handles_missing_precip_value(self):
+        target = date(2026, 5, 10)
+        periods = [
+            _make_period(
+                datetime(2026, 5, 10, 6, tzinfo=AUSTIN_TZ),
+                True,
+                probabilityOfPrecipitation={"value": None},
+            ),
+        ]
+        result = _summarize_periods_for_date(periods, target)
+        assert result is not None
+        assert result["precip_chance"] is None
+
+    def test_skips_malformed_period(self):
+        target = date(2026, 5, 10)
+        periods = [
+            {"startTime": "not-a-date", "isDaytime": True, "temperature": 80},
+            _make_period(datetime(2026, 5, 10, 6, tzinfo=AUSTIN_TZ), True),
+        ]
+        result = _summarize_periods_for_date(periods, target)
+        assert result is not None
+        assert result["high"] == 78
+
+
+def _mock_httpx_client(points_payload, forecast_payload):
+    client = MagicMock()
+    points_resp = MagicMock()
+    points_resp.json.return_value = points_payload
+    points_resp.raise_for_status.return_value = None
+    forecast_resp = MagicMock()
+    forecast_resp.json.return_value = forecast_payload
+    forecast_resp.raise_for_status.return_value = None
+    client.get.side_effect = [points_resp, forecast_resp]
+    cm = MagicMock()
+    cm.__enter__.return_value = client
+    cm.__exit__.return_value = False
+    return cm
+
+
+class TestGetWeather:
+    def test_returns_summary_for_date_in_window(self):
+        target = date(2026, 5, 10)
+        points_payload = {
+            "properties": {"forecast": "https://api.weather.gov/gridpoints/EWX/156,90/forecast"}
+        }
+        forecast_payload = {
+            "properties": {
+                "periods": [
+                    _make_period(datetime(2026, 5, 10, 6, tzinfo=AUSTIN_TZ), True, temperature=82),
+                    _make_period(
+                        datetime(2026, 5, 10, 19, tzinfo=AUSTIN_TZ), False, temperature=66
+                    ),
+                ]
+            }
+        }
+        with patch.object(
+            poll_day_info.httpx,
+            "Client",
+            return_value=_mock_httpx_client(points_payload, forecast_payload),
+        ):
+            result = get_weather(target)
+        assert result is not None
+        assert result["high"] == 82
+        assert result["low"] == 66
+
+    def test_returns_none_outside_forecast_window(self):
+        target = date(2030, 1, 1)
+        points_payload = {
+            "properties": {"forecast": "https://api.weather.gov/gridpoints/EWX/156,90/forecast"}
+        }
+        forecast_payload = {
+            "properties": {
+                "periods": [
+                    _make_period(datetime(2026, 5, 10, 6, tzinfo=AUSTIN_TZ), True),
+                ]
+            }
+        }
+        with patch.object(
+            poll_day_info.httpx,
+            "Client",
+            return_value=_mock_httpx_client(points_payload, forecast_payload),
+        ):
+            result = get_weather(target)
+        assert result is None
+
+    def test_returns_none_on_http_error(self):
+        client = MagicMock()
+        client.get.side_effect = httpx.ConnectError("nope")
+        cm = MagicMock()
+        cm.__enter__.return_value = client
+        cm.__exit__.return_value = False
+        with patch.object(poll_day_info.httpx, "Client", return_value=cm):
+            result = get_weather(date(2026, 5, 10))
+        assert result is None
+
+    def test_caches_forecast_response(self):
+        target = date(2026, 5, 10)
+        points_payload = {
+            "properties": {"forecast": "https://api.weather.gov/gridpoints/EWX/156,90/forecast"}
+        }
+        forecast_payload = {
+            "properties": {
+                "periods": [
+                    _make_period(datetime(2026, 5, 10, 6, tzinfo=AUSTIN_TZ), True),
+                    _make_period(datetime(2026, 5, 10, 19, tzinfo=AUSTIN_TZ), False),
+                ]
+            }
+        }
+        client_mock = MagicMock()
+        with patch.object(
+            poll_day_info.httpx, "Client", return_value=client_mock
+        ) as client_factory:
+            client_mock.__enter__.return_value = MagicMock(
+                get=MagicMock(
+                    side_effect=[
+                        MagicMock(
+                            json=MagicMock(return_value=points_payload),
+                            raise_for_status=MagicMock(),
+                        ),
+                        MagicMock(
+                            json=MagicMock(return_value=forecast_payload),
+                            raise_for_status=MagicMock(),
+                        ),
+                    ]
+                )
+            )
+            client_mock.__exit__.return_value = False
+            get_weather(target)
+            # Second call should use cache, not re-instantiate the HTTP client.
+            get_weather(target)
+            assert client_factory.call_count == 1
+
+
+class TestGetPollDayInfo:
+    def test_includes_sunrise_and_date_even_when_weather_unavailable(self):
+        client = MagicMock()
+        client.get.side_effect = httpx.ConnectError("nope")
+        cm = MagicMock()
+        cm.__enter__.return_value = client
+        cm.__exit__.return_value = False
+        with patch.object(poll_day_info.httpx, "Client", return_value=cm):
+            result = get_poll_day_info(date(2026, 5, 10))
+        assert result["date"] == date(2026, 5, 10)
+        assert isinstance(result["sunrise"], time)
+        assert result["weather"] is None


### PR DESCRIPTION
Closes #283.

## Summary
- Tournament-location poll cards now show Austin sunrise time + (when within NWS's ~7-day forecast window) the predicted high/low and conditions for the tournament date.
- Sunrise is computed locally via `astral` (no API). Weather is fetched from the public NWS API (`api.weather.gov`, no key required) and cached in-memory for 30 minutes.
- Failures degrade gracefully: NWS unreachable → only sunrise renders; full lookup raises → no day-info block at all (caught in `list_polls.py` so it can never break the poll page).

## Files changed
- `core/helpers/poll_day_info.py` — new helper (`get_sunrise`, `get_weather`, `get_poll_day_info`).
- `routes/voting/list_polls.py` — attaches `poll['day_info']` for tournament polls.
- `templates/macros.html` — new `poll_day_info_card` macro.
- `templates/polls.html` — renders the new card on active tournament-location polls (above the seasonal-history block).
- `requirements.txt`, `requirements-ci.txt`, `flake.nix` — `astral==3.2`.
- `tests/unit/test_poll_day_info.py` — sunrise calc + mocked NWS lookup, including cache, error, and out-of-window cases.

## Test plan
- [x] `nix develop -c format-code` — clean
- [x] `nix develop -c check-code` — ruff + mypy clean (252 source files)
- [x] `nix develop -c run-tests` — 970 passed, 1 skipped, 78% coverage
- [ ] Manual: open `/polls` as a member, confirm an active tournament-location poll shows sunrise; confirm weather appears for tournament dates within ~7 days and is hidden (with the explanatory note) for dates further out.
- [ ] Manual: temporarily blackhole `api.weather.gov` (or unplug network) and confirm the poll page still renders with sunrise only.

## Notes
- A single Austin (30.2672, -97.7431) coordinate is used for all lakes — they're all within ~50 mi, so per-lake forecasts would be over-engineering.
- The NWS API requires a `User-Agent`; the helper sets `SABC-Tournament-App (https://github.com/envasquez/SABC)`.
- 30-min cache is module-level in-memory. Survives request boundaries within a worker but not restarts. Acceptable for our traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)