### PR TITLE
PR 1/6: Security hardening — CSRF, |safe XSS, account enum, shell scripts

### DIFF
--- a/core/csrf_middleware.py
+++ b/core/csrf_middleware.py
@@ -1,10 +1,40 @@
 """Custom CSRF middleware that supports both headers and form data."""
 
 import functools
+from email import policy
+from email.message import EmailMessage
+from email.parser import BytesParser
+from typing import Optional
 
 from starlette.requests import Request
 from starlette.types import Receive, Scope, Send
 from starlette_csrf.middleware import CSRFMiddleware as BaseCSRFMiddleware
+
+
+def _extract_multipart_csrf_token(body: bytes, content_type: str) -> Optional[str]:
+    """Extract csrf_token from a multipart/form-data body using stdlib MIME parsing.
+
+    Returns the token if a part named "csrf_token" is found, else None. Returns
+    None on any parse failure so the middleware falls through to CSRF rejection
+    rather than crashing on malformed scanner payloads.
+    """
+    try:
+        header_bytes = f"Content-Type: {content_type}\r\n\r\n".encode("utf-8")
+        parser = BytesParser(EmailMessage, policy=policy.default)
+        msg = parser.parsebytes(header_bytes + body)
+        if not msg.is_multipart():
+            return None
+        for part in msg.iter_parts():
+            cd = part.get("Content-Disposition", "")
+            if 'name="csrf_token"' not in cd:
+                continue
+            content = part.get_content()
+            if isinstance(content, bytes):
+                content = content.decode("utf-8", errors="replace")
+            return str(content).strip() or None
+    except Exception:
+        return None
+    return None
 
 
 class CSRFMiddleware(BaseCSRFMiddleware):
@@ -64,14 +94,7 @@ class CSRFMiddleware(BaseCSRFMiddleware):
                         form_data = parse_qs(decoded_body)
                         submitted_csrf_token = form_data.get("csrf_token", [None])[0]
                     elif "multipart/form-data" in content_type:
-                        body_str = body.decode("utf-8", errors="ignore")
-                        if 'name="csrf_token"' in body_str:
-                            # Simple extraction - find csrf_token value
-                            import re
-
-                            match = re.search(r'name="csrf_token"\r?\n\r?\n([^\r\n]+)', body_str)
-                            if match:
-                                submitted_csrf_token = match.group(1)
+                        submitted_csrf_token = _extract_multipart_csrf_token(body, content_type)
 
                     # Create a new receive callable that replays the cached body
                     async def receive_with_cached_body():

--- a/deploy-docker.sh
+++ b/deploy-docker.sh
@@ -1,28 +1,32 @@
 #!/bin/bash
 # deploy-docker.sh - One-command Docker deployment
 
-set -e
+set -euo pipefail
 
 echo "🚀 SABC Docker Deployment Script"
 echo "================================"
 
-# Configuration
-REMOTE_USER="root"
-REMOTE_HOST="your-droplet-ip"
-REMOTE_DIR="/opt/sabc"
+# Configuration — override via env or first positional arg.
+REMOTE_USER="${REMOTE_USER:-deploy}"
+REMOTE_HOST="${REMOTE_HOST:-}"
+REMOTE_DIR="${REMOTE_DIR:-/opt/sabc}"
 
 # Colors for output
-RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Check if remote host is provided
-if [ "$1" ]; then
+# Check if remote host is provided as positional arg
+if [ "${1:-}" ]; then
     REMOTE_HOST="$1"
 fi
 
-echo -e "${YELLOW}📍 Deploying to: $REMOTE_USER@$REMOTE_HOST${NC}"
+if [ -z "$REMOTE_HOST" ] || [ "$REMOTE_HOST" = "your-droplet-ip" ]; then
+    echo "❌ REMOTE_HOST is required. Pass as first arg or export REMOTE_HOST=<ip>."
+    exit 1
+fi
+
+echo -e "${YELLOW}📍 Deploying to: ${REMOTE_USER}@${REMOTE_HOST}${NC}"
 echo ""
 
 # Create deployment package
@@ -41,11 +45,11 @@ tar -czf sabc-deploy.tar.gz \
 
 # Upload to server
 echo "📤 Uploading to server..."
-scp sabc-deploy.tar.gz $REMOTE_USER@$REMOTE_HOST:/tmp/
+scp sabc-deploy.tar.gz "${REMOTE_USER}@${REMOTE_HOST}:/tmp/"
 
 # Deploy on server
 echo "🔧 Deploying on server..."
-ssh $REMOTE_USER@$REMOTE_HOST << 'ENDSSH'
+ssh "${REMOTE_USER}@${REMOTE_HOST}" << 'ENDSSH'
     set -e
 
     # Create app directory
@@ -66,14 +70,14 @@ ssh $REMOTE_USER@$REMOTE_HOST << 'ENDSSH'
 
     # Stop existing containers
     echo "🛑 Stopping existing containers..."
-    docker compose -f docker compose.prod.yml --env-file .env.production down 2>/dev/null || true
+    docker compose -f docker-compose.prod.yml --env-file .env.production down 2>/dev/null || true
 
     # Build and start containers
     echo "🏗️  Building containers..."
-    docker compose -f docker compose.prod.yml --env-file .env.production build
+    docker compose -f docker-compose.prod.yml --env-file .env.production build
 
     echo "🚀 Starting containers..."
-    docker compose -f docker compose.prod.yml --env-file .env.production up -d
+    docker compose -f docker-compose.prod.yml --env-file .env.production up -d
 
     # Wait for services to be ready
     echo "⏳ Waiting for services to start..."
@@ -81,8 +85,8 @@ ssh $REMOTE_USER@$REMOTE_HOST << 'ENDSSH'
 
     # Initialize database
     echo "🗃️  Initializing database..."
-    docker compose -f docker compose.prod.yml --env-file .env.production exec -T web python scripts/setup_db.py
-    docker compose -f docker compose.prod.yml --env-file .env.production exec -T web python scripts/setup_admin.py --non-interactive || echo "Admin already exists"
+    docker compose -f docker-compose.prod.yml --env-file .env.production exec -T web python scripts/setup_db.py
+    docker compose -f docker-compose.prod.yml --env-file .env.production exec -T web python scripts/setup_admin.py --non-interactive || echo "Admin already exists"
 
     # Check health
     echo "🏥 Checking application health..."
@@ -95,17 +99,17 @@ ssh $REMOTE_USER@$REMOTE_HOST << 'ENDSSH'
     # Show container status
     echo ""
     echo "📊 Container Status:"
-    docker compose -f docker compose.prod.yml --env-file .env.production ps
+    docker compose -f docker-compose.prod.yml --env-file .env.production ps
 
     echo ""
     echo "✅ Deployment complete!"
     echo "🌐 Access your site at: http://$(hostname -I | awk '{print $1}')"
     echo ""
     echo "📝 Useful commands:"
-    echo "  View logs:    docker compose -f docker compose.prod.yml logs -f"
-    echo "  Restart:      docker compose -f docker compose.prod.yml restart"
-    echo "  Stop:         docker compose -f docker compose.prod.yml down"
-    echo "  Backup DB:    docker compose -f docker compose.prod.yml exec postgres pg_dump -U sabc_user sabc > backup.sql"
+    echo "  View logs:    docker compose -f docker-compose.prod.yml logs -f"
+    echo "  Restart:      docker compose -f docker-compose.prod.yml restart"
+    echo "  Stop:         docker compose -f docker-compose.prod.yml down"
+    echo "  Backup DB:    docker compose -f docker-compose.prod.yml exec postgres pg_dump -U sabc_user sabc > backup.sql"
 ENDSSH
 
 # Cleanup
@@ -114,6 +118,6 @@ rm sabc-deploy.tar.gz
 echo ""
 echo -e "${GREEN}🎉 Deployment successful!${NC}"
 echo -e "${YELLOW}Next steps:${NC}"
-echo "1. SSH into server: ssh $REMOTE_USER@$REMOTE_HOST"
+echo "1. SSH into server: ssh ${REMOTE_USER}@${REMOTE_HOST}"
 echo "2. Edit /opt/sabc/.env.production with your values"
-echo "3. Restart: cd /opt/sabc && docker compose -f docker compose.prod.yml --env-file .env.production restart"
+echo "3. Restart: cd /opt/sabc && docker compose -f docker-compose.prod.yml --env-file .env.production restart"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,7 +6,7 @@ services:
     container_name: sabc-web
     restart: always
     environment:
-      DATABASE_URL: postgresql://sabc_user:${DB_PASSWORD:-secure_password}@postgres:5432/sabc
+      DATABASE_URL: postgresql://sabc_user:${DB_PASSWORD:?DB_PASSWORD must be set in .env.production}@postgres:5432/sabc
       SECRET_KEY: ${SECRET_KEY}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       DEBUG: ${DEBUG:-false}
@@ -49,7 +49,7 @@ services:
     environment:
       POSTGRES_DB: sabc
       POSTGRES_USER: sabc_user
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-secure_password}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD must be set in .env.production}
       POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=en_US.utf8"
     ports:
       - "5432:5432"

--- a/re-cert.sh
+++ b/re-cert.sh
@@ -1,9 +1,24 @@
 #!/usr/bin/bash
+# Renews SSL certification.
+# Paths can be overridden via env vars to support non-default deployments.
 
-# Renews SSL certification
+set -euo pipefail
+
+DOMAIN="${CERT_DOMAIN:-saustinbc.com}"
+LETSENCRYPT_LIVE="${LETSENCRYPT_LIVE:-/etc/letsencrypt/live/${DOMAIN}}"
+SSL_DEST="${SSL_DEST:-/home/sabc/SABC/ssl}"
+
+if [ ! -d "$LETSENCRYPT_LIVE" ]; then
+    echo "❌ Let's Encrypt live dir not found: $LETSENCRYPT_LIVE" >&2
+    exit 1
+fi
+if [ ! -d "$SSL_DEST" ]; then
+    echo "❌ SSL destination dir not found: $SSL_DEST" >&2
+    exit 1
+fi
 
 docker stop sabc-nginx
 certbot renew --force-renewal
-cp /etc/letsencrypt/live/saustinbc.com/fullchain.pem /home/sabc/SABC/ssl/
-cp /etc/letsencrypt/live/saustinbc.com/privkey.pem /home/sabc/SABC/ssl/
+cp "${LETSENCRYPT_LIVE}/fullchain.pem" "${SSL_DEST}/"
+cp "${LETSENCRYPT_LIVE}/privkey.pem" "${SSL_DEST}/"
 docker start sabc-nginx

--- a/restart.sh
+++ b/restart.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 # Production deployment script with database migrations
 
-set -e  # Exit on any error
+set -euo pipefail
 
 echo "🚀 Starting deployment..."
 

--- a/routes/admin/users/update_user/save.py
+++ b/routes/admin/users/update_user/save.py
@@ -114,17 +114,7 @@ async def update_user(
             "UNIQUE constraint failed: anglers.email" in error_str
             or "unique constraint" in error_str.lower()
         ):
-            with get_session() as session:
-                existing = (
-                    session.query(Angler)
-                    .filter(Angler.email == update_params["email"], Angler.id != user_id)
-                    .first()
-                )
-                error_msg = (
-                    f"Email '{update_params['email']}' already belongs to {existing.name}"
-                    if existing
-                    else f"Email '{update_params['email']}' is already in use"
-                )
+            error_msg = "This email address is already in use."
         else:
             error_msg = "Failed to update user"
         return error_redirect("/admin/users", error_msg)

--- a/scripts/reset_staging_db.sh
+++ b/scripts/reset_staging_db.sh
@@ -14,7 +14,7 @@
 #   - PostgreSQL client (psql) must be installed
 #   - Python with required dependencies must be available
 
-set -e  # Exit on error
+set -euo pipefail
 
 # Colors for output
 RED='\033[0;31m'

--- a/setup-https.sh
+++ b/setup-https.sh
@@ -3,7 +3,7 @@
 # HTTPS Setup Script for SABC
 # Run this on your production server
 
-set -e
+set -euo pipefail
 
 echo "🔐 Setting up HTTPS for South Austin Bass Club"
 echo "================================================"
@@ -14,6 +14,17 @@ if [[ $EUID -eq 0 ]]; then
    exit 1
 fi
 
+# Require SECRET_KEY (or pull from .env.production if present) before any
+# docker-compose operation so we never start prod containers with a placeholder.
+if [ -z "${SECRET_KEY:-}" ] && [ -f .env.production ]; then
+    # shellcheck disable=SC1091
+    set -a && . ./.env.production && set +a
+fi
+if [ -z "${SECRET_KEY:-}" ]; then
+    echo "❌ SECRET_KEY is not set. Export it or put it in .env.production before running."
+    exit 1
+fi
+
 # Check if domain resolves to this server
 echo "📡 Checking if saustinbc.com points to this server..."
 DOMAIN_IP=$(dig +short saustinbc.com)
@@ -22,7 +33,7 @@ SERVER_IP=$(curl -s ifconfig.me)
 if [ "$DOMAIN_IP" != "$SERVER_IP" ]; then
     echo "⚠️  Warning: saustinbc.com ($DOMAIN_IP) doesn't point to this server ($SERVER_IP)"
     echo "   Make sure your DNS is configured correctly before proceeding."
-    read -p "Continue anyway? (y/N): " -n 1 -r
+    read -r -p "Continue anyway? (y/N): " -n 1 REPLY
     echo
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         exit 1
@@ -40,7 +51,7 @@ fi
 
 # Stop current containers
 echo "🛑 Stopping current containers..."
-SECRET_KEY=your-secret-key-here docker compose -f docker-compose.prod.yml down
+docker compose -f docker-compose.prod.yml down
 
 # Create SSL directory
 echo "📁 Creating SSL directory..."
@@ -60,11 +71,11 @@ sudo certbot certonly --standalone \
 echo "📋 Copying certificates..."
 sudo cp /etc/letsencrypt/live/saustinbc.com/fullchain.pem ssl/
 sudo cp /etc/letsencrypt/live/saustinbc.com/privkey.pem ssl/
-sudo chown $USER:$USER ssl/*.pem
+sudo chown "$USER:$USER" ssl/*.pem
 
 # Start containers with HTTPS
 echo "🚀 Starting containers with HTTPS..."
-SECRET_KEY=your-secret-key-here docker compose -f docker-compose.prod.yml up -d
+docker compose -f docker-compose.prod.yml up -d
 
 # Wait for startup
 echo "⏳ Waiting for services to start..."

--- a/templates/index.html
+++ b/templates/index.html
@@ -100,7 +100,7 @@
             {% if tournament.google_maps_iframe %}
             <div style="border-radius:var(--r-md);overflow:hidden;position:relative;height:180px;margin-bottom:1rem">
                 <style>.map-container-next iframe{position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:0}</style>
-                <div class="map-container-next" style="width:100%;height:100%">{{ tournament.google_maps_iframe|safe }}</div>
+                <div class="map-container-next" style="width:100%;height:100%">{{ tournament.google_maps_iframe|sanitize_iframe }}</div>
             </div>
             {% endif %}
         </div>
@@ -167,7 +167,7 @@
                     {% if not tournament.is_cancelled and tournament.google_maps_iframe %}
                     <div style="border-radius:var(--r-md);overflow:hidden;position:relative;height:160px;margin-top:.75rem">
                         <style>.map-c-{{ tournament.id }} iframe{position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:0}</style>
-                        <div class="map-c-{{ tournament.id }}" style="width:100%;height:100%">{{ tournament.google_maps_iframe|safe }}</div>
+                        <div class="map-c-{{ tournament.id }}" style="width:100%;height:100%">{{ tournament.google_maps_iframe|sanitize_iframe }}</div>
                     </div>
                     {% endif %}
 
@@ -341,7 +341,7 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body p-0">
-                    <div style="height:400px;width:100%">{{ tournament.ramp_google_maps|safe }}</div>
+                    <div style="height:400px;width:100%">{{ tournament.ramp_google_maps|sanitize_iframe }}</div>
                 </div>
                 <div class="modal-footer">
                     <span style="color:var(--t3);font-size:.82rem">{{ tournament.lake_display_name }}</span>

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -31,7 +31,7 @@
 {% set field_id = id or name %}
 <div class="fg">
     <label for="{{ field_id }}" class="fl">
-        {{ label|safe }}
+        {{ label }}
         {% if required %}<span style="color:var(--err)">*</span>{% endif %}
     </label>
     {% if type == 'textarea' %}
@@ -55,7 +55,7 @@
                {% if required %}required{% endif %}>
     {% endif %}
     {% if help_text %}
-        <div style="font-size:.72rem;color:var(--t4);margin-top:.2rem">{{ help_text|safe }}</div>
+        <div style="font-size:.72rem;color:var(--t4);margin-top:.2rem">{{ help_text }}</div>
     {% endif %}
 </div>
 {% endmacro %}


### PR DESCRIPTION
## Summary
First of 6 sequenced refactor PRs derived from a deep five-agent code analysis. This PR contains the security-relevant fixes that came out of that audit; correctness, slimming, frontend, CSS, and infra follow in PRs 2-6.

## Changes
**CSRF middleware** ([core/csrf_middleware.py](core/csrf_middleware.py))
- Replace hand-rolled regex multipart parsing with stdlib `email.parser`. The old regex assumed no extra part headers between `Content-Disposition` and the value and exact `\r\n\r\n` separators; legitimate browsers and edge cases broke it. The new path uses Python's MIME machinery and falls through to CSRF rejection on parse failure.

**XSS surface reduction**
- `templates/macros.html`: remove `|safe` from the `form_field` macro's label and help_text. Neither needed it for current callers and both were XSS sinks if any future caller passed user-derived strings.
- `templates/index.html` (3 sites): swap `|safe` on `tournament.google_maps_iframe` / `tournament.ramp_google_maps` for the existing `|sanitize_iframe` filter (already defined in `core/helpers/sanitize.py` and registered in `app_setup.py`). The filter only emits iframes whose `src` matches `google.com/maps` — anything else returns empty.

**Account enumeration**
- `routes/admin/users/update_user/save.py`: the unique-email error path used to return ``f\"Email '{email}' already belongs to {existing.name}\"``, leaking which account owns the colliding email. Replaced with a generic ``\"This email address is already in use.\"`` and dropped the extra DB roundtrip that fetched the conflicting row.

**Shell-script hardening**
- `setup-https.sh`: drop the hardcoded ``SECRET_KEY=your-secret-key-here`` env prefix from both compose invocations. Require ``SECRET_KEY`` via env or ``.env.production`` and fail-fast if absent. ``set -euo pipefail``, quote ``$USER``.
- `deploy-docker.sh`: fix ``docker compose.prod.yml`` typo (missing hyphen — meant ``-f docker`` was parsed as the compose file). Drop default ``REMOTE_HOST=\"your-droplet-ip\"`` and require it explicitly. Quote all ssh/scp targets. ``set -euo pipefail``.
- `restart.sh`, `re-cert.sh`, `scripts/reset_staging_db.sh`: ``set -euo pipefail``.
- `re-cert.sh`: parameterize cert paths via env vars, validate dirs exist before copying.

**Fail-hard secrets in prod compose**
- `docker-compose.prod.yml`: ``${DB_PASSWORD:-secure_password}`` → ``${DB_PASSWORD:?DB_PASSWORD must be set in .env.production}``. Prod containers now refuse to start without a real password rather than silently using the literal word ``secure_password``.

## What is intentionally NOT in this PR
- The CSRF exemptions on ``/login``, ``/logout``, ``/register``, ``/forgot-password``, ``/reset-password`` in [app_setup.py:104-112](app_setup.py#L104-L112) are documented as intentional (rate limiting + bcrypt + email verification + cryptographic reset tokens). Worth a future discussion but not changed here.
- ``psycopg2-binary`` vs ``psycopg`` driver split between ``requirements.txt`` and ``requirements-ci.txt`` is deferred to the infra PR (PR 6).
- The agent's claim that ``/health`` was missing was a false positive — it lives in ``routes/pages/health.py`` at 100% coverage.

## Test plan
- [x] `nix develop -c format-code` — clean
- [x] `nix develop -c check-code` — ruff + mypy clean (252 source files)
- [x] `nix develop -c run-tests` — 973 passed, 1 skipped (rate-limit test, staging only), coverage 77.93%
- [x] Smoke: load the home page (verify map iframes still render via `sanitize_iframe`)
- [ ] Smoke: open the admin user edit form, attempt a duplicate-email update (verify generic error)
- [x] Smoke: submit any multipart form (e.g. photo upload) and confirm CSRF still validates
- [x] When deploying: confirm ``DB_PASSWORD`` is set in ``.env.production`` before pulling this — otherwise prod compose will refuse to start (this is the intended behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)