### PR TITLE
PR 3/6: Backend slimming — PaginationState helper + 303 standardization

### DIFF
--- a/core/helpers/pagination.py
+++ b/core/helpers/pagination.py
@@ -1,0 +1,65 @@
+"""Pagination helper used by paginated views."""
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass(frozen=True)
+class PaginationState:
+    """Immutable pagination state with derived fields.
+
+    Centralizes the (total + per_page - 1) // per_page math and the
+    has_prev / has_next / prev_page / next_page fields that admin and public
+    paginated views need.
+    """
+
+    page: int
+    items_per_page: int
+    total_items: int
+
+    @property
+    def total_pages(self) -> int:
+        if self.total_items <= 0:
+            return 1
+        return (self.total_items + self.items_per_page - 1) // self.items_per_page
+
+    @property
+    def offset(self) -> int:
+        return (max(self.page, 1) - 1) * self.items_per_page
+
+    @property
+    def has_prev(self) -> bool:
+        return self.page > 1
+
+    @property
+    def has_next(self) -> bool:
+        return self.page < self.total_pages
+
+    @property
+    def prev_page(self) -> int:
+        return self.page - 1
+
+    @property
+    def next_page(self) -> int:
+        return self.page + 1
+
+    def is_out_of_range(self) -> bool:
+        """True if the requested page is past the last valid page."""
+        return self.page > self.total_pages and self.total_pages > 0
+
+    def to_template_context(self, prefix: str = "") -> Dict[str, Any]:
+        """Return a flat dict of pagination fields for Jinja template context.
+
+        ``prefix`` lets one view expose multiple paginators (e.g. admin events
+        with upcoming + past tabs). With prefix="upcoming", keys become
+        upcoming_page / upcoming_total_pages / upcoming_has_prev / ...
+        """
+        p = f"{prefix}_" if prefix else ""
+        return {
+            f"{p}page": self.page,
+            f"{p}total_pages": self.total_pages,
+            f"{p}has_prev": self.has_prev,
+            f"{p}has_next": self.has_next,
+            f"{p}prev_page": self.prev_page,
+            f"{p}next_page": self.next_page,
+        }

--- a/routes/admin/core/dashboard.py
+++ b/routes/admin/core/dashboard.py
@@ -6,6 +6,7 @@ from sqlalchemy import Date, Integer, cast, func
 
 from core.db_schema import Event, Poll, get_session
 from core.helpers.auth import require_admin
+from core.helpers.pagination import PaginationState
 from core.helpers.timezone import now_local
 from routes.admin.core.dashboard_data import get_tournaments_data, get_users_data
 from routes.admin.core.event_queries import get_sabc_tournaments, get_upcoming_events_data
@@ -20,7 +21,7 @@ VALID_ADMIN_PAGES = {"events", "users", "tournaments"}
 @router.get("/admin")
 async def admin_root(request: Request):
     _user = require_admin(request)
-    return RedirectResponse("/admin/events", status_code=302)
+    return RedirectResponse("/admin/events", status_code=303)
 
 
 @router.get("/admin/{page}")
@@ -96,25 +97,19 @@ async def admin_page(request: Request, page: str, upcoming_page: int = 1, past_p
         ctx["past_tournament_lakes"] = past_tournament_lakes
         ctx["available_polls"] = available_polls
 
-        upcoming_total_pages = (total_upcoming + per_page - 1) // per_page
+        upcoming_pagination = PaginationState(
+            page=upcoming_page, items_per_page=per_page, total_items=total_upcoming
+        )
         # Past tournaments don't use pagination - all loaded for client-side filtering
-        past_total_pages = 1
         total_past = len(past_tournaments)
+        past_pagination = PaginationState(
+            page=past_page, items_per_page=total_past or 1, total_items=total_past
+        )
+        ctx.update(upcoming_pagination.to_template_context(prefix="upcoming"))
+        ctx.update(past_pagination.to_template_context(prefix="past"))
         ctx.update(
             {
-                "upcoming_page": upcoming_page,
-                "upcoming_total_pages": upcoming_total_pages,
-                "upcoming_has_prev": upcoming_page > 1,
-                "upcoming_has_next": upcoming_page < upcoming_total_pages,
-                "upcoming_prev_page": upcoming_page - 1,
-                "upcoming_next_page": upcoming_page + 1,
                 "total_upcoming": total_upcoming,
-                "past_page": past_page,
-                "past_total_pages": past_total_pages,
-                "past_has_prev": past_page > 1,
-                "past_has_next": past_page < past_total_pages,
-                "past_prev_page": past_page - 1,
-                "past_next_page": past_page + 1,
                 "total_past": total_past,
                 "per_page": per_page,
             }

--- a/routes/admin/core/news.py
+++ b/routes/admin/core/news.py
@@ -137,7 +137,7 @@ async def create_news(
             # Log email failure but don't fail the news post creation
             logger.error(f"Failed to send news notifications: {email_error}")
 
-        return RedirectResponse("/admin/news?success=News created successfully", status_code=302)
+        return RedirectResponse("/admin/news?success=News created successfully", status_code=303)
     except SQLAlchemyError as e:
         logger.error(f"Failed to create news: {e}", exc_info=True)
         return error_redirect("/admin/news", "Failed to create news post")
@@ -152,7 +152,7 @@ async def edit_news_form(request: Request, news_id: int):
         news_item = session.query(News).filter(News.id == news_id).first()
         if not news_item:
             return RedirectResponse(
-                f"/admin/news?error=News item with ID {news_id} not found", status_code=302
+                f"/admin/news?error=News item with ID {news_id} not found", status_code=303
             )
 
     # Return the admin news page with the news item data
@@ -214,7 +214,7 @@ async def update_news(
                     news_item.expires_at = expires_at
                 # Context manager will commit automatically on successful exit
 
-        return RedirectResponse("/admin/news?success=News updated successfully", status_code=302)
+        return RedirectResponse("/admin/news?success=News updated successfully", status_code=303)
     except SQLAlchemyError as e:
         logger.error(f"Failed to update news: {e}", exc_info=True)
         return error_redirect("/admin/news", "Failed to update news post")
@@ -242,7 +242,7 @@ async def test_news_email(request: Request, title: str = Form(...), content: str
 
         if success:
             return RedirectResponse(
-                f"/admin/news?success=Test email sent to {admin_email}", status_code=302
+                f"/admin/news?success=Test email sent to {admin_email}", status_code=303
             )
         else:
             return error_redirect(
@@ -291,7 +291,7 @@ async def archive_news(request: Request, news_id: int) -> RedirectResponse:
                 news_item.archived = True
                 news_item.updated_at = utc_now()
 
-        return RedirectResponse("/admin/news?success=News archived successfully", status_code=302)
+        return RedirectResponse("/admin/news?success=News archived successfully", status_code=303)
     except SQLAlchemyError as e:
         logger.error(f"Failed to archive news: {e}")
         return error_redirect("/admin/news", "Failed to archive news")
@@ -311,7 +311,7 @@ async def unarchive_news(request: Request, news_id: int) -> RedirectResponse:
 
         return RedirectResponse(
             "/admin/news?show_archived=true&success=News restored successfully",
-            status_code=302,
+            status_code=303,
         )
     except SQLAlchemyError as e:
         logger.error(f"Failed to unarchive news: {e}")

--- a/routes/admin/events/create_event.py
+++ b/routes/admin/events/create_event.py
@@ -66,7 +66,7 @@ async def create_event(
         if validation["errors"]:
             error_msg = "; ".join(validation["errors"])
             return RedirectResponse(
-                f"/admin/events?error=Validation failed: {error_msg}", status_code=302
+                f"/admin/events?error=Validation failed: {error_msg}", status_code=303
             )
         warning_msg = ""
         if validation["warnings"]:
@@ -93,7 +93,7 @@ async def create_event(
             create_poll_options(poll_id)
             link_tournament_to_poll(event_id, poll_id)
         return RedirectResponse(
-            f"/admin/events?success=Event created successfully{warning_msg}", status_code=302
+            f"/admin/events?success=Event created successfully{warning_msg}", status_code=303
         )
     except (SQLAlchemyError, ValueError) as e:
         return handle_event_error(e, date, "create")

--- a/routes/admin/events/error_handlers.py
+++ b/routes/admin/events/error_handlers.py
@@ -19,4 +19,4 @@ def get_error_message(error: Exception, date: str, operation: str = "update") ->
 def handle_event_error(e: Exception, date: str, operation: str = "update") -> RedirectResponse:
     """Handle errors during event create/update and redirect with error message."""
     error_msg = get_error_message(e, date, operation)
-    return RedirectResponse(f"/admin/events?error={error_msg}", status_code=302)
+    return RedirectResponse(f"/admin/events?error={error_msg}", status_code=303)

--- a/routes/admin/events/update_event.py
+++ b/routes/admin/events/update_event.py
@@ -44,7 +44,7 @@ def _do_event_update(
     if validation["errors"]:
         error_msg = "; ".join(validation["errors"])
         return RedirectResponse(
-            f"/admin/events?error=Validation failed: {error_msg}", status_code=302
+            f"/admin/events?error=Validation failed: {error_msg}", status_code=303
         )
 
     event_params, tournament_params = prepare_event_params(
@@ -67,7 +67,7 @@ def _do_event_update(
         rowcount = update_event_record(session, event_params)
         if rowcount == 0:
             return RedirectResponse(
-                f"/admin/events?error=Event with ID {event_id} not found", status_code=302
+                f"/admin/events?error=Event with ID {event_id} not found", status_code=303
             )
 
         if event_type in ["sabc_tournament", "other_tournament"]:
@@ -75,7 +75,7 @@ def _do_event_update(
             if tournament_rowcount == 0:
                 return RedirectResponse(
                     f"/admin/events?error=Tournament record for event ID {event_id} not found",
-                    status_code=302,
+                    status_code=303,
                 )
 
     if event_type == "sabc_tournament":
@@ -83,7 +83,7 @@ def _do_event_update(
         if poll_id:
             update_tournament_poll_id(event_id, int(poll_id))
 
-    return RedirectResponse("/admin/events?success=Event updated successfully", status_code=302)
+    return RedirectResponse("/admin/events?success=Event updated successfully", status_code=303)
 
 
 @router.get("/admin/events/{event_id}/edit")
@@ -95,7 +95,7 @@ async def get_edit_event(request: Request, event_id: int):
         event = session.query(Event).filter(Event.id == event_id).first()
         if not event:
             return RedirectResponse(
-                f"/admin/events?error=Event with ID {event_id} not found", status_code=302
+                f"/admin/events?error=Event with ID {event_id} not found", status_code=303
             )
 
     return templates.TemplateResponse(

--- a/routes/admin/lakes/lake_operations.py
+++ b/routes/admin/lakes/lake_operations.py
@@ -37,7 +37,7 @@ async def create_lake(
                 google_maps_iframe=sanitize_iframe(google_maps_embed),
             )
             session.add(lake)
-        return RedirectResponse("/admin/lakes?success=Lake created successfully", status_code=302)
+        return RedirectResponse("/admin/lakes?success=Lake created successfully", status_code=303)
     except HTTPException:
         raise
     except IntegrityError:
@@ -66,7 +66,7 @@ async def update_lake(
             lake.yaml_key = name.strip().lower().replace(" ", "_")
             lake.display_name = display_name.strip()
             lake.google_maps_iframe = sanitize_iframe(google_maps_embed)
-        return RedirectResponse("/admin/lakes?success=Lake updated successfully", status_code=302)
+        return RedirectResponse("/admin/lakes?success=Lake updated successfully", status_code=303)
     except HTTPException:
         raise
     except SQLAlchemyError:

--- a/routes/admin/lakes/ramp_operations.py
+++ b/routes/admin/lakes/ramp_operations.py
@@ -27,7 +27,7 @@ async def create_ramp(
             )
             session.add(ramp)
         return RedirectResponse(
-            f"/admin/lakes/{lake_id}/edit?success=Ramp added successfully", status_code=302
+            f"/admin/lakes/{lake_id}/edit?success=Ramp added successfully", status_code=303
         )
     except SQLAlchemyError:
         return error_redirect(f"/admin/lakes/{lake_id}/edit", "Failed to add ramp")
@@ -53,7 +53,7 @@ async def update_ramp(
             ramp.google_maps_iframe = sanitize_iframe(google_maps_iframe)
 
         return RedirectResponse(
-            f"/admin/lakes/{lake_id}/edit?success=Ramp updated successfully", status_code=302
+            f"/admin/lakes/{lake_id}/edit?success=Ramp updated successfully", status_code=303
         )
     except SQLAlchemyError:
         redirect_path = f"/admin/lakes/{lake_id}/edit" if lake_id else "/admin/lakes"

--- a/routes/admin/polls/create_poll/form.py
+++ b/routes/admin/polls/create_poll/form.py
@@ -49,7 +49,7 @@ async def create_poll_form(request: Request, event_id: int = Query(None)):
                 if existing_poll:
                     return RedirectResponse(
                         f"/admin/polls/{existing_poll.id}/edit?info=Poll already exists for this event",
-                        status_code=302,
+                        status_code=303,
                     )
 
         context = {
@@ -63,5 +63,5 @@ async def create_poll_form(request: Request, event_id: int = Query(None)):
         return templates.TemplateResponse("admin/create_poll.html", context)
     except SQLAlchemyError:
         return RedirectResponse(
-            "/admin/events?error=Failed to load poll creation form", status_code=302
+            "/admin/events?error=Failed to load poll creation form", status_code=303
         )

--- a/routes/admin/polls/create_poll/handler.py
+++ b/routes/admin/polls/create_poll/handler.py
@@ -108,7 +108,7 @@ async def create_poll(request: Request) -> RedirectResponse:
         )
 
         return RedirectResponse(
-            f"/admin/polls/{poll_id}/edit?success=Poll created successfully", status_code=302
+            f"/admin/polls/{poll_id}/edit?success=Poll created successfully", status_code=303
         )
 
     except IntegrityError as e:

--- a/routes/admin/polls/create_poll/helpers.py
+++ b/routes/admin/polls/create_poll/helpers.py
@@ -32,7 +32,7 @@ def validate_and_get_event(
             if existing_poll:
                 return None, RedirectResponse(
                     f"/admin/polls/{existing_poll.id}/edit?error=Poll already exists for this event",
-                    status_code=302,
+                    status_code=303,
                 )
 
             return event, None

--- a/routes/admin/polls/edit_poll_form.py
+++ b/routes/admin/polls/edit_poll_form.py
@@ -75,4 +75,4 @@ async def edit_poll_form(request: Request, poll_id: int):
                 return templates.TemplateResponse("admin/edit_poll.html", context)
 
     except SQLAlchemyError:
-        return RedirectResponse("/polls?error=Failed to load poll", status_code=302)
+        return RedirectResponse("/polls?error=Failed to load poll", status_code=303)

--- a/routes/admin/polls/edit_poll_save.py
+++ b/routes/admin/polls/edit_poll_save.py
@@ -34,7 +34,7 @@ async def update_poll(request: Request, poll_id: int) -> RedirectResponse:
 
         if not title:
             return RedirectResponse(
-                f"/admin/polls/{poll_id}/edit?error=Title is required", status_code=302
+                f"/admin/polls/{poll_id}/edit?error=Title is required", status_code=303
             )
 
         # Parse datetime strings - interpret as Central Time (club timezone)
@@ -48,7 +48,7 @@ async def update_poll(request: Request, poll_id: int) -> RedirectResponse:
         with get_session() as session:
             poll = session.query(Poll).filter(Poll.id == poll_id).first()
             if not poll:
-                return RedirectResponse("/admin/polls?error=Poll not found", status_code=302)
+                return RedirectResponse("/admin/polls?error=Poll not found", status_code=303)
 
             # Store poll_type before session closes
             poll_type = poll.poll_type
@@ -151,7 +151,7 @@ async def update_poll(request: Request, poll_id: int) -> RedirectResponse:
             success_msg += f". Note: Some options ({', '.join(kept_options_with_votes)}) could not be removed because they have existing votes."
 
         return RedirectResponse(
-            f"/admin/polls/{poll_id}/edit?success={success_msg}", status_code=302
+            f"/admin/polls/{poll_id}/edit?success={success_msg}", status_code=303
         )
     except (SQLAlchemyError, ValueError) as e:
         logger.error(
@@ -165,5 +165,5 @@ async def update_poll(request: Request, poll_id: int) -> RedirectResponse:
         )
         return RedirectResponse(
             f"/admin/polls/{poll_id}/edit?error=Failed to update poll. Please try again.",
-            status_code=302,
+            status_code=303,
         )

--- a/routes/admin/users/update_user/save.py
+++ b/routes/admin/users/update_user/save.py
@@ -99,12 +99,12 @@ async def update_user(
         if after != before:
             log_update_completed(request, user, user_id, update_params, before, after)
             return RedirectResponse(
-                "/admin/users?success=User updated and verified", status_code=302
+                "/admin/users?success=User updated and verified", status_code=303
             )
         else:
             log_update_failed(user, user_id, update_params)
             return RedirectResponse(
-                "/admin/users?error=Update failed - no changes saved", status_code=302
+                "/admin/users?error=Update failed - no changes saved", status_code=303
             )
 
     except (SQLAlchemyError, ValueError) as e:

--- a/routes/pages/home.py
+++ b/routes/pages/home.py
@@ -29,6 +29,7 @@ from core.deps import templates
 from core.email import send_contact_email
 from core.helpers.auth import get_user_optional
 from core.helpers.logging import get_logger
+from core.helpers.pagination import PaginationState
 from core.helpers.poll_day_info import get_poll_day_info
 from core.helpers.response import error_redirect, success_redirect
 from core.query_service import QueryService
@@ -53,20 +54,23 @@ async def home_paginated(request: Request, page: int = 1):
             or 0
         )
 
-        # Calculate total pages and validate page number
-        total_pages = (
-            (total_completed_tournaments + items_per_page - 1) // items_per_page
-            if total_completed_tournaments > 0
-            else 1
+        pagination = PaginationState(
+            page=page,
+            items_per_page=items_per_page,
+            total_items=total_completed_tournaments,
         )
 
-        # Validate page is within bounds - redirect to last page if too high
-        if page > total_pages and total_pages > 0:
-            return RedirectResponse(f"/?p={total_pages}", status_code=303)
+        if pagination.is_out_of_range():
+            return RedirectResponse(f"/?p={pagination.total_pages}", status_code=303)
 
-        # Ensure page is at least 1
         page = max(1, page)
-        offset = (page - 1) * items_per_page
+        pagination = PaginationState(
+            page=page,
+            items_per_page=items_per_page,
+            total_items=total_completed_tournaments,
+        )
+        offset = pagination.offset
+        total_pages = pagination.total_pages
 
         # Base query for tournament data
         def build_tournament_query(complete_filter: bool | None = None):
@@ -418,11 +422,11 @@ async def home_paginated(request: Request, page: int = 1):
             "request": request,
             "user": user,
             "all_tournaments": tournaments_with_results,
-            "current_page": page,
-            "total_pages": total_pages,
+            "current_page": pagination.page,
+            "total_pages": pagination.total_pages,
             "page_range": page_range,
-            "has_prev": page > 1,
-            "has_next": page < total_pages,
+            "has_prev": pagination.has_prev,
+            "has_next": pagination.has_next,
             "start_index": start_index,
             "end_index": end_index,
             "total_tournaments": total_completed_tournaments,

--- a/routes/password_reset/request_reset.py
+++ b/routes/password_reset/request_reset.py
@@ -67,7 +67,7 @@ async def request_password_reset(
 
         return RedirectResponse(
             "/forgot-password?success=If that email is in our system, we've sent you a password reset link. Please check your email (and spam folder).",
-            status_code=302,
+            status_code=303,
         )
     except (SQLAlchemyError, OSError, ValueError) as e:
         logger.error(f"Error processing password reset request: {e}", exc_info=True)

--- a/routes/password_reset/reset_password.py
+++ b/routes/password_reset/reset_password.py
@@ -100,7 +100,7 @@ async def process_password_reset(
         )
         return RedirectResponse(
             "/login?success=Your password has been successfully reset. You can now log in with your new password.",
-            status_code=302,
+            status_code=303,
         )
     except (SQLAlchemyError, ValueError) as e:
         logger.error(f"Error processing password reset: {e}", exc_info=True)

--- a/tests/integration/test_admin_news_dashboard.py
+++ b/tests/integration/test_admin_news_dashboard.py
@@ -445,7 +445,7 @@ class TestAdminDashboard:
     def test_admin_root_redirects_to_events(self, admin_client: TestClient):
         """Admin root should redirect to events page."""
         response = admin_client.get("/admin", follow_redirects=False)
-        assert response.status_code == 302
+        assert response.status_code == 303
         assert "/admin/events" in response.headers.get("location", "")
 
     def test_admin_events_page(self, admin_client: TestClient):

--- a/tests/integration/test_event_deletion_password_reset.py
+++ b/tests/integration/test_event_deletion_password_reset.py
@@ -231,7 +231,7 @@ class TestPasswordResetRequest:
             follow_redirects=False,
         )
 
-        assert response.status_code == 302
+        assert response.status_code == 303
         assert "success" in response.headers.get("location", "").lower()
 
         # Verify email was sent
@@ -256,7 +256,7 @@ class TestPasswordResetRequest:
         )
 
         # Should still show success to prevent email enumeration
-        assert response.status_code == 302
+        assert response.status_code == 303
         assert "success" in response.headers.get("location", "").lower()
 
         # But should not send email
@@ -301,7 +301,7 @@ class TestPasswordResetRequest:
             follow_redirects=False,
         )
 
-        assert response.status_code == 302
+        assert response.status_code == 303
         mock_create_token.assert_called_once_with(member_user.id, member_user.email)
 
 


### PR DESCRIPTION
## Summary
Third of 6 sequenced refactor PRs. Adds a small reusable pagination helper, applies it to the two views with hand-rolled pagination, and standardizes POST-redirect-GET on HTTP 303. **Re-scoped from the original plan** — splitting ``data_queries.py`` / ``home.py`` / ``gallery.py`` / ``seed_staging_data.py`` is deferred (rationale below).

## Changes
**[core/helpers/pagination.py](core/helpers/pagination.py) (new)** — ``PaginationState`` frozen dataclass. Computes ``total_pages``, ``offset``, ``has_prev``, ``has_next``, ``prev_page``, ``next_page``, and an ``is_out_of_range()`` check. ``to_template_context(prefix=...)`` produces the flat Jinja key set so views can expose multiple paginators in one context (e.g. admin events tab has upcoming + past).

**[routes/pages/home.py](routes/pages/home.py)** — replaces the inline ``(total + per_page - 1) // per_page`` and ``offset = (page - 1) * items_per_page`` block with ``PaginationState``. Template keys unchanged.

**[routes/admin/core/dashboard.py](routes/admin/core/dashboard.py)** — replaces the two hand-built paginator key sets (``upcoming_*`` and ``past_*``) with ``upcoming_pagination.to_template_context(prefix=\"upcoming\")`` / ``past_pagination.to_template_context(prefix=\"past\")``. Template contract unchanged.

**302 → 303 across all POST-redirect-GET handlers** — mechanical conversion in 14 routing files:
- admin/polls (create, edit, form, save, helpers)
- admin/core (news, dashboard root)
- admin/lakes (lake_operations, ramp_operations)
- admin/users (update_user/save)
- admin/events (create, update, error_handlers)
- password_reset (request, reset)

Two tests that hard-coded ``status_code == 302`` were updated to 303. 303 explicitly forces GET on the redirected request, which is the correct semantics for form submissions; 302 leaves method handling implementation-defined. Browsers behave identically for both, so this is a no-op for the UI — but it cleans up the contract for HTTP clients that care.

## Why this PR is smaller than the original PR 3 plan

The audit recommended also splitting ``core/query_service/data_queries.py`` (790 LOC), ``routes/pages/home.py`` (622 LOC), ``routes/photos/gallery.py`` (602 LOC), and ``scripts/seed_staging_data.py`` (916 LOC). After reading them in detail:

- **data_queries.py**: the \"5x UNION ALL duplication\" is actually 4 distinct patterns — some need ``e.year, e.date``, some need ``disqualified``, some use a NOT-EXISTS-based fallback, some build a ``ranked_results`` CTE with ``ROW_NUMBER()``. Extracting one CTE helper would require either a fat select-all fragment or templated SQL, both of which hurt query readability and optimizability. The current file is self-contained well-documented SQL; the split has a poor risk/reward.
- **home.py / gallery.py / seed_staging_data.py**: each warrants its own focused PR with smoke testing. Bundling four splits into one PR maximizes regression risk for minimal review benefit.

These remain on the audit list and should be picked off in dedicated follow-ups.

## Test plan
- [x] ``nix develop -c format-code`` — clean
- [x] ``nix develop -c check-code`` — ruff + mypy clean (253 files)
- [x] ``nix develop -c run-tests`` — 973 passed, 1 skipped, coverage 78.1%
- [x] Smoke: paginate through the home page (verify Next/Prev work, last-page redirect still works)
- [x] Smoke: admin events page with upcoming and past tab paginators
- [x] Smoke: submit any admin form, confirm redirect lands on the GET page as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)