### PR TITLE
PR 4/6: Frontend cleanup — single escapeHtml, strict ID equality, missing credentials

### DIFF
--- a/static/admin-news.js
+++ b/static/admin-news.js
@@ -125,21 +125,15 @@ function populateNewsConfirm(mode, title, content, priority, archive) {
 
     let html = '<dl class="row mb-0" style="margin:0">';
     html += '<dt class="col-sm-3"><i class="bi bi-card-text me-1"></i>Content</dt>';
-    html += '<dd class="col-sm-9" style="white-space:pre-wrap;word-break:break-word">' + escapeNewsHtml(content) + '</dd>';
+    html += '<dd class="col-sm-9" style="white-space:pre-wrap;word-break:break-word">' + escapeHtml(content) + '</dd>';
     html += '<dt class="col-sm-3"><i class="bi bi-flag me-1"></i>Priority</dt>';
-    html += '<dd class="col-sm-9 fw-bold">' + escapeNewsHtml(priorityLabel) + '</dd>';
+    html += '<dd class="col-sm-9 fw-bold">' + escapeHtml(priorityLabel) + '</dd>';
     if (archive) {
         html += '<dt class="col-sm-3"><i class="bi bi-archive me-1"></i>Auto Archive</dt>';
-        html += '<dd class="col-sm-9">' + escapeNewsHtml(archive) + '</dd>';
+        html += '<dd class="col-sm-9">' + escapeHtml(archive) + '</dd>';
     }
     html += '</dl>';
     summary.innerHTML = html;
-}
-
-function escapeNewsHtml(text) {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
 }
 
 function sendTestEmail() {

--- a/static/calendar.js
+++ b/static/calendar.js
@@ -38,7 +38,7 @@ function showEventDetails(element) {
     const eventKey = month + '-' + day;
 
     // Select the appropriate event details based on year
-    const eventDetails = (year == currentYear) ? currentEventDetails : nextEventDetails;
+    const eventDetails = (Number(year) === Number(currentYear)) ? currentEventDetails : nextEventDetails;
 
     if (eventDetails[eventKey]) {
         const events = eventDetails[eventKey];

--- a/static/enter-results.js
+++ b/static/enter-results.js
@@ -715,6 +715,7 @@ function createGuest() {
     // Send request to create guest
     fetch('/admin/users', {
         method: 'POST',
+        credentials: 'same-origin',
         headers: {
             'Content-Type': 'application/json',
             'x-csrf-token': getCsrfToken(),

--- a/static/polls.js
+++ b/static/polls.js
@@ -288,9 +288,9 @@ class PollVotingHandler {
 
         let summary = '<dl class="row mb-0">';
         summary += '<dt class="col-sm-4"><i class="bi bi-geo-alt me-1"></i>Lake</dt>';
-        summary += '<dd class="col-sm-8 fw-bold">' + this.escapeHtml(lakeName) + '</dd>';
+        summary += '<dd class="col-sm-8 fw-bold">' + escapeHtml(lakeName) + '</dd>';
         summary += '<dt class="col-sm-4"><i class="bi bi-signpost me-1"></i>Ramp</dt>';
-        summary += '<dd class="col-sm-8 fw-bold">' + this.escapeHtml(rampName) + '</dd>';
+        summary += '<dd class="col-sm-8 fw-bold">' + escapeHtml(rampName) + '</dd>';
         summary += '<dt class="col-sm-4"><i class="bi bi-clock me-1"></i>Start Time</dt>';
         summary += '<dd class="col-sm-8 fw-bold">' + startTime + '</dd>';
         summary += '<dt class="col-sm-4"><i class="bi bi-clock-history me-1"></i>End Time</dt>';
@@ -302,7 +302,7 @@ class PollVotingHandler {
             const memberSelect = document.getElementById(ids.member);
             const memberName = memberSelect?.selectedOptions[0]?.text || 'Unknown';
             summary += '<div class="mt-2 pt-2 border-top">';
-            summary += '<small class="text-warning"><i class="bi bi-person-badge me-1"></i>Voting on behalf of: <strong>' + this.escapeHtml(memberName) + '</strong></small>';
+            summary += '<small class="text-warning"><i class="bi bi-person-badge me-1"></i>Voting on behalf of: <strong>' + escapeHtml(memberName) + '</strong></small>';
             summary += '</div>';
         }
 
@@ -326,7 +326,7 @@ class PollVotingHandler {
 
         let summary = '<div class="d-flex align-items-center">';
         summary += '<i class="bi bi-check-circle-fill text-success me-2" style="font-size: 1.5rem;"></i>';
-        summary += '<span class="fw-bold">' + this.escapeHtml(optionText) + '</span>';
+        summary += '<span class="fw-bold">' + escapeHtml(optionText) + '</span>';
         summary += '</div>';
 
         return summary;
@@ -345,18 +345,6 @@ class PollVotingHandler {
         const ampm = h >= 12 ? 'PM' : 'AM';
         const h12 = h % 12 || 12;
         return h12 + ':' + minutes + ' ' + ampm;
-    }
-
-    /**
-     * Escape HTML to prevent XSS
-     * @param {string} text - Text to escape
-     * @returns {string} Escaped text
-     * @private
-     */
-    escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
     }
 
     /**

--- a/static/utils.js
+++ b/static/utils.js
@@ -666,7 +666,7 @@ class LakeRampSelector {
         }
         // Handle array format: [{id: 1, name: 'Lake Travis', ramps: [...]}, ...]
         else if (Array.isArray(this.lakesData)) {
-            const lake = this.lakesData.find(l => l.id == lakeId);
+            const lake = this.lakesData.find(l => Number(l.id) === Number(lakeId));
             if (lake && lake.ramps) {
                 this.populateRamps(lake.ramps, 'id', 'name');
             } else {
@@ -828,7 +828,7 @@ function formatTime12Hour(time24) {
 function getLakeName(lakesData, lakeId) {
     if (!lakeId) return 'Unknown Lake';
     if (lakesData && Array.isArray(lakesData)) {
-        const lake = lakesData.find(function(l) { return l.id == lakeId; });
+        const lake = lakesData.find(function(l) { return Number(l.id) === Number(lakeId); });
         if (lake) return lake.name;
     }
     return 'Lake ' + lakeId;
@@ -851,7 +851,7 @@ function getRampName(lakesData, rampId) {
     if (!rampId) return 'Unknown Ramp';
     if (lakesData && Array.isArray(lakesData)) {
         for (let i = 0; i < lakesData.length; i++) {
-            const ramp = (lakesData[i].ramps || []).find(function(r) { return r.id == rampId; });
+            const ramp = (lakesData[i].ramps || []).find(function(r) { return Number(r.id) === Number(rampId); });
             if (ramp) return ramp.name;
         }
     }


### PR DESCRIPTION
## Summary
Frontend cleanup, deliberately small. The original PR 4 plan included splitting utils.js (1470 LOC) and enter-results.js (1003 LOC) into focused modules — that's deferred. There's no bundler, every template that loads scripts would need touching, and there's zero user-visible benefit for considerable regression risk.

## Changes
**One escapeHtml**
- [static/utils.js](static/utils.js) is the canonical owner (already exported on window).
- Delete the local copy in [static/admin-news.js](static/admin-news.js) (\`escapeNewsHtml\`, 5 lines, used 3 times in the same file).
- Delete the \`PollVotingHandler.escapeHtml\` method in [static/polls.js](static/polls.js) (11 lines including docblock, used 4 times in the same class).
- All callers now use the global. Load order is fine: [templates/polls.html:770-771](templates/polls.html#L770-L771) loads \`utils.js\` first; [templates/base.html:155](templates/base.html#L155) loads \`utils.js\` before any per-page script.

**Strict equality on numeric ID lookups**
- 3 sites in [utils.js](static/utils.js) (lakes/ramps lookup) and 1 in [calendar.js](static/calendar.js) used \`==\` because parameters arrive as number-or-string (data attributes give strings, some code pre-parses). Switched to \`Number(a) === Number(b)\` — type-explicit and won't break if anyone changes the input shape.

**Missing credentials on createGuest fetch**
- [enter-results.js:716](static/enter-results.js#L716) — the \`/admin/users\` POST didn't pass \`credentials: 'same-origin'\`. Every other fetch in the file already does. Without it, the session cookie isn't sent, the CSRF cookie isn't sent, and the token in the header has nothing to validate against. Browsers usually still send cookies for same-origin requests, but \"usually\" isn't a contract — making this explicit.

## What is NOT in this PR (and won't be)
- **utils.js / enter-results.js module split** — no bundler in the repo, all scripts are loaded via plain \`<script>\` tags, and splitting either file would require touching every template that loads it. Zero user-visible benefit, real regression risk. The files stay monolithic.
- **\`securePost()\` helper** — looked at it; existing CSRF patterns (FormData with csrf_token field for form-submit paths, x-csrf-token header for JSON paths) are correct and converged. There were only 2 patterns to begin with, not 3 as the original audit claimed.
- **HTMX listener-leak fix** — verified the codebase only uses HTMX in one place (photo gallery pagination) and that page reinitializes its handlers on \`htmx:afterSwap\`. The supposed leak doesn't exist on this codebase.
- **Submit-button disable on form submit** — separate UX concern, not part of this cleanup.

## Test plan
- [x] \`nix develop -c format-code\` — clean
- [x] \`nix develop -c check-code\` — ruff + mypy clean
- [x] \`nix develop -c run-tests\` — 970 passed, 1 skipped, coverage 78.1%
- [x] Smoke: load the news admin page, edit an item, verify the read-only preview renders escaped content.
- [x] Smoke: open a poll voting form, verify the confirmation modal renders the lake/ramp/option text correctly.
- [x] Smoke: open the calendar, click a day in both this-year and next-year — verify the right event details show.
- [x] Smoke: open enter-results, click \"Create Guest\", verify the guest gets created and appears in the angler dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)