### PR TITLE
Fix: sanitize_iframe accepts single-quoted attributes (lake maps were rendering empty)

### DIFF
--- a/core/helpers/sanitize.py
+++ b/core/helpers/sanitize.py
@@ -47,9 +47,12 @@ def sanitize_iframe(raw_html: str) -> str:
     if not raw_html or not raw_html.strip():
         return ""
 
-    # Match iframe with a Google Maps src URL (multiple valid domains/paths)
+    # Match iframe with a Google Maps src URL. Tolerate both single- and
+    # double-quoted attribute values: the seed data in scripts/lakes_production.json
+    # ships single-quoted iframes (Google's "Share/Embed map" UI emitted those
+    # historically), and the output normalizes to double quotes regardless.
     match = re.search(
-        r'<iframe\s[^>]*src="(https://(?:www\.google\.com/maps|maps\.google\.com/maps)[^"]*)"[^>]*>',
+        r"""<iframe\s[^>]*src=["'](https://(?:www\.google\.com/maps|maps\.google\.com/maps)[^"']*)["'][^>]*>""",
         raw_html,
         re.IGNORECASE,
     )

--- a/tests/unit/test_sanitize_comprehensive.py
+++ b/tests/unit/test_sanitize_comprehensive.py
@@ -5,8 +5,44 @@ from core.helpers.sanitize import (
     sanitize_event_data,
     sanitize_for_json,
     sanitize_html,
+    sanitize_iframe,
     sanitize_lakes_data,
 )
+
+
+class TestSanitizeIframe:
+    """Lake/ramp Google Maps iframes must render through sanitize_iframe."""
+
+    def test_double_quoted_attributes(self):
+        """Iframes copy-pasted from Google Maps with double quotes pass through."""
+        src = "https://www.google.com/maps/embed?pb=!1m18!1m12"
+        raw = f'<iframe src="{src}" width="600" height="450"></iframe>'
+        out = sanitize_iframe(raw)
+        assert src in out
+        assert out.startswith("<iframe")
+
+    def test_single_quoted_attributes(self):
+        """Production seed data ships single-quoted iframes — must still match.
+
+        Regression: scripts/lakes_production.json stores iframes like
+        <iframe src='https://www.google.com/maps/embed?pb=...' width='100%'>.
+        The original regex only accepted double quotes, which made every
+        lake/ramp map silently render as empty on the home page.
+        """
+        src = "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3"
+        raw = f"<iframe src='{src}' width='100%' height='100%'></iframe>"
+        out = sanitize_iframe(raw)
+        assert src in out
+        assert out.startswith("<iframe")
+
+    def test_non_google_src_rejected(self):
+        """Non-Google iframes get stripped (security contract)."""
+        raw = '<iframe src="https://evil.example.com/xss"></iframe>'
+        assert sanitize_iframe(raw) == ""
+
+    def test_empty_input_returns_empty(self):
+        assert sanitize_iframe("") == ""
+        assert sanitize_iframe("   ") == ""
 
 
 class TestSanitize:


### PR DESCRIPTION
## Summary
Hotfix for a regression introduced by [PR #285](https://github.com/envasquez/SABC/pull/285): every Google Maps iframe on the home page (and anywhere ``|sanitize_iframe`` is applied) was rendering empty because the regex didn't accept single-quoted attributes.

## Root cause
The seed data in [scripts/lakes_production.json](scripts/lakes_production.json) ships iframes formatted like:

\`\`\`html
<iframe src='https://www.google.com/maps/embed?pb=...' width='100%' height='100%'></iframe>
\`\`\`

That's the format Google's *Share / Embed map* UI emitted historically. The regex in [core/helpers/sanitize.py:52](core/helpers/sanitize.py#L52) only matched double-quoted attributes:

\`\`\`python
r'<iframe\\s[^>]*src=\"(https://(?:www\\.google\\.com/maps|maps\\.google\\.com/maps)[^\"]*)\"[^>]*>'
\`\`\`

Pre-PR-285 these rendered via ``|safe`` (no sanitization). PR #285 swapped to ``|sanitize_iframe``, so every lake/ramp iframe started failing the regex and the filter returned empty. The sanitize-on-write path in ``lake_operations.py``/``ramp_operations.py`` didn't catch this earlier because the production data was loaded via seed, never going through the admin form.

## Fix
One-character class change: ``\"`` → ``[\"']`` in two positions:

\`\`\`python
r'''<iframe\\s[^>]*src=[\"'](https://(?:www\\.google\\.com/maps|maps\\.google\\.com/maps)[^\"']*)[\"'][^>]*>'''
\`\`\`

Output still normalizes to double quotes, so the first render through the filter also cleans up the stored data shape.

## Tests
Added 4 regression tests in [tests/unit/test_sanitize_comprehensive.py](tests/unit/test_sanitize_comprehensive.py):
- Double-quoted attributes pass through
- **Single-quoted attributes pass through** (regression for this bug)
- Non-Google ``src`` is still rejected (security contract intact)
- Empty input returns empty

## Test plan
- [x] ``nix develop -c format-code`` — clean
- [x] ``nix develop -c check-code`` — ruff + mypy clean
- [x] ``nix develop -c run-tests`` — 974 passed, 1 skipped, coverage 78.1%
- [x] User confirmed maps render again locally after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)