### PR TITLE
PR 6/6: Infra — drop dead pytest coverage config, dev Dockerfile non-root, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # Production runtime dependencies (requirements.txt) — hits psycopg2-binary,
+  # fastapi, sqlalchemy, pillow, etc. Group patch+minor into one PR so weekly
+  # updates aren't N noise PRs; major versions ship as separate PRs so they
+  # get individual review.
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      python-runtime-minor:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor
+
+  # GitHub Actions versions in .github/workflows/*.yml.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,12 @@ RUN apt-get update && apt-get install -y sqlite3  && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-RUN mkdir -p /app/data
+
+# Match prod: run as non-root so dev catches permission bugs prod would hit.
+RUN useradd -m -u 1000 sabc && \
+    mkdir -p /app/data /app/uploads/photos && \
+    chown -R sabc:sabc /app
+USER sabc
+
 EXPOSE 8000
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -33,35 +33,6 @@ markers =
     slow: Slow running tests (skip with -m "not slow")
     skip_ci: Skip in CI environment
 
-# Coverage settings
-[coverage:run]
-source = .
-omit =
-    */tests/*
-    */test_*
-    */__pycache__/*
-    */venv/*
-    */env/*
-    */.venv/*
-    */.nix-python-packages/*
-    */site-packages/*
-    */conftest.py
-    */scripts/*
-
-[coverage:report]
-precision = 2
-show_missing = True
-skip_covered = False
-exclude_lines =
-    pragma: no cover
-    def __repr__
-    def __str__
-    raise AssertionError
-    raise NotImplementedError
-    if __name__ == .__main__.:
-    if TYPE_CHECKING:
-    @abstract
-    @abc.abstractmethod
-
-[coverage:html]
-directory = htmlcov
+# Coverage settings live in pyproject.toml ([tool.coverage.*]) — coverage.py
+# does not read [coverage:*] sections from pytest.ini, so duplicating them
+# here was dead config.


### PR DESCRIPTION
## Summary
Final scheduled PR of the refactor series. Three small, low-risk infrastructure changes. Bigger infra items (psycopg driver unification, nginx consolidation, CI bandit hardening, flake.nix command additions) are deliberately deferred to focused follow-ups — rationale in commit body.

## Changes

**[pytest.ini](pytest.ini)** — remove dead ``[coverage:*]`` sections.
coverage.py reads its config from ``[tool.coverage.*]`` in ``pyproject.toml`` (or ``.coveragerc``/``setup.cfg``/``tox.ini``), **not** from ``[coverage:*]`` sections in ``pytest.ini``. The real config has lived in ``pyproject.toml`` the whole time. Replaced the duplicated-and-ignored sections with a one-line note pointing at the actual config.

**[Dockerfile](Dockerfile)** (dev) — add non-root user.
``Dockerfile.prod`` already has ``useradd -m -u 1000 sabc`` / ``USER sabc``. Dev didn't, so it was running as root. File-permission bugs that surface in prod now also surface locally before deploy.

**[.github/dependabot.yml](.github/dependabot.yml)** (new) — weekly dependency PRs.
- Python deps via ``pip`` ecosystem; patch+minor updates grouped into one weekly PR to keep noise down; major versions ship as individual PRs for review.
- GitHub Actions versions in ``.github/workflows/*.yml``.
- Capped at 5 open pip PRs and 3 open Actions PRs.

## Deliberately NOT in this PR

| Item | Reason |
|---|---|
| ``flake.nix`` ``test-backend``/``test-frontend`` commands | No node toolchain in the nix env; ``test-frontend`` would have no meaningful implementation. ``run-tests --coverage`` already covers the coverage case. |
| ``psycopg2-binary`` → ``psycopg`` unification | DB driver swap is genuinely high-risk; needs its own test pass and rollback plan. |
| ``nginx.conf`` ↔ ``nginx-https.conf`` consolidation | Prod web routing change; needs deliberate review. |
| CI ``continue-on-error: false`` for bandit/safety | Tightening blindly will break CI on every push. First need to enumerate what bandit currently reports and decide which findings to allowlist. |

Each of these is on the radar but warrants its own focused PR.

## Test plan
- [x] ``nix develop -c format-code`` — clean
- [x] ``nix develop -c check-code`` — ruff + mypy clean (253 files)
- [x] ``nix develop -c run-tests`` — 970 passed, 1 skipped, coverage 78.1%
- [x] When deploying: rebuild ``docker-compose.dev.yml`` images so the dev container runs as the non-root sabc user. If anyone has dev containers running, they should ``docker compose down && docker compose up --build``.
- [x] After merge: dependabot will open its first batch of PRs on next Monday; nothing to verify until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)