### PR TITLE
PR 7: Post-audit cleanup — SECRET_KEY fail-hard, Pillow pin, api/lakes errors, JS credentials

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,7 +7,7 @@ services:
     restart: always
     environment:
       DATABASE_URL: postgresql://sabc_user:${DB_PASSWORD:?DB_PASSWORD must be set in .env.production}@postgres:5432/sabc
-      SECRET_KEY: ${SECRET_KEY}
+      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY must be set in .env.production}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       DEBUG: ${DEBUG:-false}
       SMTP_USERNAME: ${SMTP_USERNAME}

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -37,7 +37,7 @@ numpy==2.3.3
 packaging==25.0
 pandas==2.2.3
 pathspec==0.12.1
-Pillow>=10.0.0
+Pillow==12.2.0
 pluggy==1.6.0
 port-for==0.7.4
 psutil==7.0.0

--- a/routes/api/lakes.py
+++ b/routes/api/lakes.py
@@ -1,9 +1,12 @@
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
+from sqlalchemy.exc import SQLAlchemyError
 
 from core.db_schema import Lake, Ramp, get_session
+from core.helpers.logging import get_logger
 
 router = APIRouter()
+logger = get_logger(__name__)
 
 
 @router.get("/api/lakes")
@@ -24,8 +27,14 @@ async def api_get_lakes():
                 for lake_id, yaml_key, display_name in lakes_query
             ]
         return JSONResponse(lakes)
-    except Exception:
-        return JSONResponse([])
+    except SQLAlchemyError as exc:
+        # Log and surface a real error rather than silently returning an empty
+        # list — admins would otherwise see "no lakes" instead of "DB down".
+        logger.error("api_get_lakes: database error", exc_info=exc)
+        return JSONResponse(
+            {"error": "Failed to load lakes"},
+            status_code=500,
+        )
 
 
 @router.get("/api/lakes/{lake_key}/ramps")

--- a/static/admin-events-lakes.js
+++ b/static/admin-events-lakes.js
@@ -10,7 +10,7 @@ let lakesData = [];
  * Load lakes data from API and populate all lake dropdowns
  */
 function loadLakes() {
-    fetch('/api/lakes')
+    fetch('/api/lakes', { credentials: 'same-origin' })
         .then(response => {
             if (!response.ok) throw new Error('Failed to load lakes');
             return response.json();

--- a/static/admin-events.js
+++ b/static/admin-events.js
@@ -22,7 +22,7 @@ function editEvent(id, date, eventType, name, description, hasPoll) {
     // Ensure lakes are loaded before proceeding
     const ensureLakesLoadedAndEdit = () => {
         // Fetch complete event data
-        fetch(`/admin/events/${id}/info`)
+        fetch(`/admin/events/${id}/info`, { credentials: 'same-origin' })
             .then(response => {
                 if (!response.ok) throw new Error('Failed to load event');
                 return response.json();
@@ -132,7 +132,7 @@ function editEvent(id, date, eventType, name, description, hasPoll) {
     // Check if lakes are already loaded
     const currentLakesData = getLakesData();
     if (currentLakesData.length === 0) {
-        fetch('/api/lakes')
+        fetch('/api/lakes', { credentials: 'same-origin' })
             .then(response => {
                 if (!response.ok) throw new Error('Failed to load lakes');
                 return response.json();

--- a/static/admin-news.js
+++ b/static/admin-news.js
@@ -158,6 +158,7 @@ function sendTestEmail() {
     // Send test email
     fetch('/admin/news/test-email', {
         method: 'POST',
+        credentials: 'same-origin',
         body: formData
     })
     .then(response => {


### PR DESCRIPTION
## Summary
Second-pass audit found 4 genuine HAS-class items that survived the 6-PR series. This is the cleanup. ~10 lines of real changes across 6 files. 974 tests pass.

## Changes

**[docker-compose.prod.yml:10](docker-compose.prod.yml#L10)** — \`SECRET_KEY\` fail-hard.
PR #285 made \`DB_PASSWORD\` fail-hard with \`\${DB_PASSWORD:?...}\` but missed the adjacent \`SECRET_KEY\` line. Prod containers would silently start with an empty signing key if the env var was missing, breaking sessions and CSRF tokens on every request. Now refuses to start.

**[requirements-ci.txt:40](requirements-ci.txt#L40)** — Pillow pinned to \`==12.2.0\` to match \`requirements.txt\`.
CI was using \`>=10.0.0\`, so tests could run against a different major version than what prod ships. (The \`psycopg2-binary\` vs \`psycopg\` driver split is still present and deliberately deferred — DB driver swap is its own focused PR.)

**[routes/api/lakes.py:27](routes/api/lakes.py#L27)** — replace bare \`except Exception\` swallowing.
Was returning empty array on any error, including DB outages. Admins had no way to distinguish "no lakes" from "DB down". Now: narrow catch on \`SQLAlchemyError\`, log via the project logger, return HTTP 500 with an error body.

**JS fetches: 4 missing \`credentials: 'same-origin'\`**
- [admin-news.js:159](static/admin-news.js#L159) — POST /admin/news/test-email (most important; CSRF token in body but session cookie wasn't being sent)
- [admin-events.js:25](static/admin-events.js#L25) — GET /admin/events/{id}/info
- [admin-events.js:135](static/admin-events.js#L135) — GET /api/lakes
- [admin-events-lakes.js:13](static/admin-events-lakes.js#L13) — GET /api/lakes

Three are read-only so impact is low. Consistency: every other fetch in the codebase already passes credentials.

## What's NOT in this PR

The second-pass audit also surfaced ~10 SHOULD-class and CAN-class items. None are blockers; all are deferred:
- N+1 risk in \`core/query_service/data_queries.py::get_club_overview_stats\` (nested year-min subscan)
- Audit-trail gap in \`core/services/account_merge.py\` (logs count of deleted votes but not which polls)
- Bare-except scope in \`core/email/tokens.py::verify_reset_token\`
- Hardcoded \`range(2023, ...)\` in profile/roster aggregates
- \`poll_day_info.py\` weather cache thread-safety
- Potential \`.card\` vs \`.cc\` CSS duplication
- \`detect-secrets\` pre-commit hook still commented out pending baseline

Each one is its own focused PR if you want to keep going.

## Test plan
- [x] \`nix develop -c format-code\` — clean
- [x] \`nix develop -c check-code\` — ruff + mypy clean (253 files)
- [x] \`nix develop -c run-tests\` — 974 passed, 1 skipped, coverage 78.1%
- [x] When deploying: make sure \`SECRET_KEY\` is set in \`.env.production\` before pulling this — compose will refuse to start otherwise (intended).
- [x] Smoke: admin events page (loads lakes via /api/lakes), news admin (send test email), confirm no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)