### PR TITLE
PR 9: Ops batch — pool budget, restart.sh atomicity, RUNBOOK

### DIFF
--- a/core/db_schema/engine.py
+++ b/core/db_schema/engine.py
@@ -10,11 +10,19 @@ if not DATABASE_URL:
         raise RuntimeError("DATABASE_URL must be set in production")
     DATABASE_URL = "postgresql://postgres:dev123@localhost:5432/sabc"
 
+# Per-worker pool budget. With gunicorn workers=4, total max DB connections is
+# workers * (DB_POOL_SIZE + DB_MAX_OVERFLOW). Old defaults (10+20) put us at
+# 120 max, over Postgres' default max_connections=100. New defaults (5+10) cap
+# at 60 with workers=4. Override via env if you bump workers or know the
+# Postgres instance allows more.
+_POOL_SIZE = int(os.environ.get("DB_POOL_SIZE", "5"))
+_MAX_OVERFLOW = int(os.environ.get("DB_MAX_OVERFLOW", "10"))
+
 engine = create_engine(
     DATABASE_URL,
     echo=False,
     pool_pre_ping=True,
-    pool_size=10,
-    max_overflow=20,
+    pool_size=_POOL_SIZE,
+    max_overflow=_MAX_OVERFLOW,
     pool_recycle=3600,
 )

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,6 +46,14 @@ services:
     image: postgres:17-alpine
     container_name: sabc-postgres
     restart: always
+    # Bump max_connections above the default 100. With workers=4 and a per-
+    # worker pool budget of 5+10, we max at 60 — but multiple gunicorn workers
+    # plus migration tasks plus the occasional pg_dump backup can spike higher.
+    # 200 leaves comfortable headroom on a 2GB+ droplet (each conn ~10MB).
+    command:
+      - "postgres"
+      - "-c"
+      - "max_connections=200"
     environment:
       POSTGRES_DB: sabc
       POSTGRES_USER: sabc_user

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,119 @@
+# Operations Runbook
+
+When something is on fire at 11 PM during a tournament weekend, you read this file.
+
+## Roll back a failed deploy
+
+`restart.sh` makes a gzip'd `pg_dump` of the prod database into `~/backups/sabc_YYYYMMDD_HHMMSS.sql.gz` **before** doing anything destructive. That backup is what you restore from.
+
+### When to roll back
+
+Roll back if any of the following is true after `restart.sh` finishes (or aborts):
+
+- The health-check loop at the end of `restart.sh` exited non-zero
+- `docker compose -f docker-compose.prod.yml logs web` shows the app crashing on startup
+- `https://saustinbc.com/health` returns 5xx or doesn't respond
+- A migration partially applied and the schema is half-broken
+- Anything user-visible is wrong and you can't immediately diagnose
+
+### Steps
+
+```bash
+# 1. Find the most recent backup (created by this deploy)
+ls -t ~/backups/sabc_*.sql.gz | head -1
+# Note the filename, e.g. ~/backups/sabc_20260513_211530.sql.gz
+
+# 2. Find the last known-good git revision (the one this deploy replaced).
+#    `git reflog` shows what HEAD was before `git pull`.
+git reflog | head -5
+# Example: HEAD@{1}: pull: Fast-forward
+# Note the commit hash on the line BEFORE the pull, e.g. c294153
+
+# 3. Stop the broken containers (don't `down` — we want postgres running for the restore)
+docker compose -f docker-compose.prod.yml stop web
+
+# 4. Restore the database
+gunzip -c ~/backups/sabc_YYYYMMDD_HHMMSS.sql.gz | \
+    docker compose -f docker-compose.prod.yml exec -T postgres psql -U sabc_user sabc
+
+# 5. Roll the code back to the previous revision
+git reset --hard <PREVIOUS_COMMIT_HASH>
+
+# 6. Rebuild and start
+docker compose -f docker-compose.prod.yml build --no-cache web
+docker compose -f docker-compose.prod.yml up -d
+
+# 7. Verify
+curl -fsS https://saustinbc.com/health
+docker compose -f docker-compose.prod.yml logs --tail=50 web
+```
+
+### If the backup restore fails
+
+The backup is a `pg_dump` in custom format compressed with gzip. If `psql` chokes:
+
+```bash
+# Inspect the backup is valid
+gunzip -t ~/backups/sabc_YYYYMMDD_HHMMSS.sql.gz && echo "gzip OK"
+gunzip -c ~/backups/sabc_YYYYMMDD_HHMMSS.sql.gz | head -50
+
+# If the database is in a weird state, drop and recreate it before restoring:
+docker compose -f docker-compose.prod.yml exec -T postgres psql -U sabc_user -d postgres \
+    -c "DROP DATABASE IF EXISTS sabc; CREATE DATABASE sabc OWNER sabc_user;"
+gunzip -c ~/backups/sabc_YYYYMMDD_HHMMSS.sql.gz | \
+    docker compose -f docker-compose.prod.yml exec -T postgres psql -U sabc_user sabc
+```
+
+## Common incidents
+
+### "too many connections for role" errors
+
+Postgres is at its `max_connections` ceiling.
+
+```bash
+# How many active connections, by source?
+docker compose -f docker-compose.prod.yml exec -T postgres \
+    psql -U sabc_user sabc -c "SELECT count(*), client_addr FROM pg_stat_activity GROUP BY client_addr;"
+
+# Kill idle connections older than 5 minutes
+docker compose -f docker-compose.prod.yml exec -T postgres \
+    psql -U sabc_user sabc -c \
+    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+     WHERE state = 'idle' AND state_change < now() - interval '5 minutes';"
+```
+
+Persistent? Lower `DB_POOL_SIZE` / `DB_MAX_OVERFLOW` in `.env.production` and restart. Defaults are 5+10 per worker; with 4 workers that's 60 max. The compose file already sets `max_connections=200`, so unless you've bumped `WORKERS` you should never hit this.
+
+### Site won't start after deploy: secret missing
+
+The app now hard-fails if `SECRET_KEY` is missing in any non-dev/non-test environment, and prod compose hard-fails if `DB_PASSWORD` or `SECRET_KEY` are missing.
+
+```bash
+# Check what's set
+grep -E '^(SECRET_KEY|DB_PASSWORD|ENVIRONMENT)=' .env.production
+# Should show all three with non-empty values.
+```
+
+Fix `.env.production` and re-run `restart.sh`.
+
+### Migrations applied but app still serves the old version
+
+The browser may be caching. Hard-refresh (Cmd-Shift-R). The CSS cache-bust param in `templates/base.html` (`?v=N`) should normally handle this — verify it was bumped if CSS changed.
+
+If the app itself appears stale: `docker compose -f docker-compose.prod.yml restart web`.
+
+### Database container stuck in restart loop
+
+```bash
+docker compose -f docker-compose.prod.yml logs --tail=100 postgres
+```
+
+Common causes: corrupt data volume (rare), permission errors on `/var/lib/postgresql/data`, or out-of-disk. Check `df -h` first.
+
+## Reference
+
+- Backups: `~/backups/sabc_*.sql.gz` (last 10 retained automatically by `restart.sh`)
+- Logs: `docker compose -f docker-compose.prod.yml logs -f web`
+- Health: `curl https://saustinbc.com/health`
+- Compose file: `docker-compose.prod.yml`
+- Env file: `.env.production` (not in git — keep a copy somewhere safe)

--- a/restart.sh
+++ b/restart.sh
@@ -1,17 +1,28 @@
 #!/usr/bin/bash
-# Production deployment script with database migrations
+# Production deployment script with database migrations.
+# Rollback procedure: see docs/RUNBOOK.md
 
 set -euo pipefail
 
+COMPOSE="docker compose -f docker-compose.prod.yml"
+HEALTH_URL="${HEALTH_URL:-http://localhost/health}"
+
 echo "🚀 Starting deployment..."
 
-# Backup database before anything else
+# 1. Pull the latest code FIRST. This is read-only and atomic — if it fails
+#    (rebase conflict, network blip, GitHub outage), we abort before touching
+#    the running site. The previous order (down → pull) meant a failed pull
+#    left the site down with no easy recovery.
+echo "📥 Pulling latest code..."
+git pull
+
+# 2. Back up the running database before any state-mutating step.
 BACKUP_DIR="$HOME/backups"
 BACKUP_FILE="$BACKUP_DIR/sabc_$(date +%Y%m%d_%H%M%S).sql.gz"
 mkdir -p "$BACKUP_DIR"
 
 echo "💾 Backing up database..."
-if docker compose -f docker-compose.prod.yml exec -T postgres pg_dump -U sabc_user sabc | gzip > "$BACKUP_FILE"; then
+if $COMPOSE exec -T postgres pg_dump -U sabc_user sabc | gzip > "$BACKUP_FILE"; then
     BACKUP_SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
     echo "✅ Backup saved: $BACKUP_FILE ($BACKUP_SIZE)"
 else
@@ -23,35 +34,46 @@ fi
 ls -t "$BACKUP_DIR"/sabc_*.sql.gz 2>/dev/null | tail -n +11 | xargs -r rm
 echo "🗂️  Retained $(ls "$BACKUP_DIR"/sabc_*.sql.gz 2>/dev/null | wc -l) backups"
 
-# Stop containers
-echo "⏹️  Stopping containers..."
-docker compose -f docker-compose.prod.yml down
+# 3. Build the new image while the old containers keep serving. Docker build
+#    doesn't touch running containers, so the site stays up during this step.
+echo "🔨 Building new image..."
+$COMPOSE build --no-cache
 
-# Pull latest code
-echo "📥 Pulling latest code..."
-git pull
+# 4. Stop the old containers and start the new ones.
+echo "⏹️  Stopping old containers..."
+$COMPOSE down
 
-# Rebuild containers
-echo "🔨 Building containers..."
-docker compose -f docker-compose.prod.yml build --no-cache
+echo "▶️  Starting new containers..."
+$COMPOSE up -d
 
-# Start containers
-echo "▶️  Starting containers..."
-docker compose -f docker-compose.prod.yml up -d
-
-# Wait for database to be ready
-echo "⏳ Waiting for database..."
+# 5. Wait for the web container to be ready before we run migrations through it.
+echo "⏳ Waiting for web container to accept exec..."
 sleep 10
 
-# Run database migrations
+# 6. Apply database migrations.
 echo "📦 Running database migrations..."
-docker compose -f docker-compose.prod.yml exec -T web alembic upgrade head
+$COMPOSE exec -T web alembic upgrade head
 
-# Check migration status
 echo "📊 Current migration version:"
-docker compose -f docker-compose.prod.yml exec -T web alembic current
+$COMPOSE exec -T web alembic current
 
-# Cleanup
+# 7. Verify the app actually serves. If this fails, the deploy reports failure
+#    and the caller knows to roll back per docs/RUNBOOK.md.
+echo "🩺 Health check..."
+HEALTH_TRIES=10
+for i in $(seq 1 "$HEALTH_TRIES"); do
+    if curl -fsS "$HEALTH_URL" >/dev/null; then
+        echo "✅ Health check passed on attempt $i"
+        break
+    fi
+    if [ "$i" -eq "$HEALTH_TRIES" ]; then
+        echo "❌ Health check failed after $HEALTH_TRIES attempts. See docs/RUNBOOK.md for rollback."
+        exit 1
+    fi
+    sleep 2
+done
+
+# 8. Host hygiene.
 echo "🧹 Cleaning up..."
 docker system prune -f
 sudo journalctl --vacuum-time=7d
@@ -60,7 +82,5 @@ sudo apt clean
 echo ""
 echo "✅ Deployment complete!"
 echo "🌐 Application: https://saustinbc.com"
-echo "📊 Check logs: docker compose -f docker-compose.prod.yml logs -f web"
-
-# To restore a backup ...
-# gunzip -c ~/backups/sabc_XXXXXXXX_XXXXXX.sql.gz | docker compose -f docker-compose.prod.yml exec -T postgres psql -U sabc_user sabc
+echo "📊 Check logs: $COMPOSE logs -f web"
+echo "↩️  Rollback steps: docs/RUNBOOK.md"


### PR DESCRIPTION
## Summary
Three operational hardenings. From the senior-pass audit: items #3 (pool size), #13 (restart.sh order), #14 (rollback runbook).

## Changes

**[core/db_schema/engine.py](core/db_schema/engine.py)** — env-driven pool budget, safer defaults.
Old: \`pool_size=10, max_overflow=20\` × \`workers=4\` = up to 120 connections, over Postgres' default \`max_connections=100\`. The app would spuriously fail to acquire connections under any concurrent traffic.
New: defaults are \`DB_POOL_SIZE=5, DB_MAX_OVERFLOW=10\` → 60 max with 4 workers. Both overridable via env if you scale.

**[docker-compose.prod.yml](docker-compose.prod.yml)** — bump Postgres ceiling.
\`postgres:17-alpine\` now starts with \`command: postgres -c max_connections=200\`. Headroom above the 60-connection app budget for migrations, pg_dump backups, and manual psql sessions. Each connection is ~10MB of RAM, so 200 × 10MB ≈ 2GB upper bound — fine on any droplet with ≥4GB.

**[restart.sh](restart.sh)** — reorder for atomicity, add health check.
Old order: \`down → pull → build → up\`. Failed pull = site is down with no recovery path.
New order: **\`pull → backup → build → down → up → health-check\`**. The pull runs read-only against a live site; if it fails we abort with zero downtime. The build runs against the still-running old containers, so the actual unavailable window shrinks to just the \`down → up\` swap. Added a curl loop on \`HEALTH_URL\` (defaults to \`http://localhost/health\`); 10 attempts × 2s. If it fails, the deploy reports failure and the script exit code points the operator at RUNBOOK.

**[docs/RUNBOOK.md](docs/RUNBOOK.md)** (new) — the actual rollback procedure.
The recovery steps were a comment at the bottom of restart.sh. Promoted to a real runbook:
- When to roll back (5 triggers)
- The actual rollback sequence: stop web → restore from \`~/backups/sabc_*.sql.gz\` → \`git reset --hard\` to previous SHA from \`git reflog\` → rebuild → verify
- Backup-restore fallback if the gzip is corrupt
- Three common incidents: too-many-connections, missing secrets, stale assets, postgres restart loops

At 11 PM during a tournament weekend you don't want this information to be a code comment nobody will think to grep.

## Test plan
- [x] \`nix develop -c format-code\` — clean
- [x] \`nix develop -c check-code\` — ruff + mypy clean
- [x] \`nix develop -c run-tests\` — 974 passed, 1 skipped
- [ ] On next deploy: confirm \`restart.sh\` exits 0 with the health check passing
- [ ] After deploy: run \`docker compose -f docker-compose.prod.yml exec postgres psql -U sabc_user sabc -c \"SHOW max_connections\"\` — should be 200
- [ ] Test the rollback procedure once in staging when you have an afternoon

🤖 Generated with [Claude Code](https://claude.com/claude-code)