### PR TITLE
PR 11: Cleanup — user dual-type, TOURNAMENT_DATA_START_YEAR constant, dead DB drivers

### DIFF
--- a/core/enums.py
+++ b/core/enums.py
@@ -1,5 +1,11 @@
 from enum import Enum
 
+# Year the club started tracking tournament data. Used by profile/roster
+# aggregates (per-year breakdowns, all-time-since-start filters). Set as a
+# named constant rather than hardcoding 2023 across a dozen sites so a
+# future backfill of historical data only needs to be done in one place.
+TOURNAMENT_DATA_START_YEAR = 2023
+
 
 class EventType(str, Enum):
     SABC_TOURNAMENT = "sabc_tournament"

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,3 @@
-aiosqlite==0.22.1
 annotated-types==0.7.0
 anyio==4.13.0
 astral==3.2
@@ -41,7 +40,6 @@ Pillow==12.2.0
 pluggy==1.6.0
 port-for==0.7.4
 psutil==7.2.2
-psycopg==3.3.4
 psycopg2-binary==2.9.12
 py-cpuinfo==9.0.0
 pycparser==2.22

--- a/routes/auth/profile.py
+++ b/routes/auth/profile.py
@@ -6,6 +6,7 @@ from sqlalchemy import case, desc, func, literal
 from sqlalchemy.exc import SQLAlchemyError
 
 from core.db_schema import Angler, Event, Result, TeamResult, Tournament, get_session
+from core.enums import TOURNAMENT_DATA_START_YEAR
 from core.helpers.logging import get_logger
 from routes.dependencies import get_current_user, templates
 
@@ -143,12 +144,12 @@ async def profile_page(request: Request) -> Response:
                 "tournaments": year_tournaments,
             }
 
-        # Get team finishes for each year (2023-current)
+        # Get team finishes for each year (since data start)
         year_finishes = {}
-        for year in range(2023, current_year + 1):
+        for year in range(TOURNAMENT_DATA_START_YEAR, current_year + 1):
             year_finishes[year] = get_year_finishes(year)
 
-        # All time finishes (team results from 2023+)
+        # All time finishes (team results since data start)
         # First, rank ALL participants within each tournament
         all_time_ranked_subquery = (
             session.query(
@@ -165,7 +166,7 @@ async def profile_page(request: Request) -> Response:
             .select_from(TeamResult)
             .join(Tournament, TeamResult.tournament_id == Tournament.id)
             .join(Event, Tournament.event_id == Event.id)
-            .filter(Event.year >= 2023)
+            .filter(Event.year >= TOURNAMENT_DATA_START_YEAR)
             .subquery()
         )
 
@@ -187,7 +188,7 @@ async def profile_page(request: Request) -> Response:
         all_time_second = all_time_finishes[1] or 0 if all_time_finishes else 0
         all_time_third = all_time_finishes[2] or 0 if all_time_finishes else 0
 
-        # Monthly weight aggregation for chart (2023-current year)
+        # Monthly weight aggregation for chart (since data start through current year)
         # Uses individual results as primary source
         # Falls back to team_results for tournaments without individual data
         from sqlalchemy import text
@@ -215,7 +216,7 @@ async def profile_page(request: Request) -> Response:
                 JOIN events e ON t.event_id = e.id
                 WHERE r.angler_id = :user_id
                   AND r.disqualified = FALSE
-                  AND {year_col} >= 2023
+                  AND {year_col} >= {TOURNAMENT_DATA_START_YEAR}
                 UNION ALL
                 -- Team results (only for tournaments without individual data)
                 -- Attribute team weight to angler1 to avoid double-counting
@@ -226,7 +227,7 @@ async def profile_page(request: Request) -> Response:
                 JOIN tournaments t ON tr.tournament_id = t.id
                 JOIN events e ON t.event_id = e.id
                 WHERE tr.angler1_id = :user_id
-                  AND {year_col} >= 2023
+                  AND {year_col} >= {TOURNAMENT_DATA_START_YEAR}
                   AND NOT EXISTS (SELECT 1 FROM results r WHERE r.tournament_id = t.id)
                 UNION ALL
                 -- Angler2 gets 0 weight for team-only tournaments (just for participation tracking)
@@ -237,7 +238,7 @@ async def profile_page(request: Request) -> Response:
                 JOIN tournaments t ON tr.tournament_id = t.id
                 JOIN events e ON t.event_id = e.id
                 WHERE tr.angler2_id = :user_id
-                  AND {year_col} >= 2023
+                  AND {year_col} >= {TOURNAMENT_DATA_START_YEAR}
                   AND NOT EXISTS (SELECT 1 FROM results r WHERE r.tournament_id = t.id)
             )
             SELECT year, month, SUM(weight) as total_weight
@@ -250,7 +251,7 @@ async def profile_page(request: Request) -> Response:
 
         # Format monthly data for Chart.js
         monthly_data: Dict[str, Any] = {}
-        for year in range(2023, current_year + 1):
+        for year in range(TOURNAMENT_DATA_START_YEAR, current_year + 1):
             monthly_data[str(year)] = [0] * 12
 
         for year, month, weight in monthly_weights:

--- a/routes/pages/home.py
+++ b/routes/pages/home.py
@@ -225,9 +225,11 @@ async def home_paginated(request: Request, page: int = 1):
                     .all()
                 )
 
-                # Check if user has voted
+                # Check if user has voted. get_user_optional always returns a
+                # UserDict (or None) — the previous defensive isinstance check
+                # was lying to the type system.
                 if user:
-                    user_id = user.get("id") if isinstance(user, dict) else user.id  # type: ignore[attr-defined]
+                    user_id = user.get("id")
                     user_vote = (
                         session.query(PollVote)
                         .filter(PollVote.poll_id == poll_id, PollVote.angler_id == user_id)

--- a/routes/pages/roster.py
+++ b/routes/pages/roster.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Request
 
 from core.db_schema import engine
 from core.deps import templates
+from core.enums import TOURNAMENT_DATA_START_YEAR
 from core.helpers.auth import get_user_optional
 from core.query_service import QueryService
 from core.query_service.dialect_helpers import (
@@ -41,7 +42,7 @@ def get_member_stats(
             "all_time_third": 0,
         }
         # Initialize year finishes for each year
-        for year in range(2023, current_year + 1):
+        for year in range(TOURNAMENT_DATA_START_YEAR, current_year + 1):
             member_stats[member_id]["year_finishes"][year] = {
                 "first": 0,
                 "second": 0,
@@ -113,7 +114,7 @@ def get_member_stats(
             FROM team_results tr
             JOIN tournaments t ON tr.tournament_id = t.id
             JOIN events e ON t.event_id = e.id
-            WHERE {year_col} >= 2023
+            WHERE {year_col} >= {TOURNAMENT_DATA_START_YEAR}
         )
         SELECT angler_id, year, place, COUNT(*) as cnt
         FROM (
@@ -161,7 +162,7 @@ def get_member_stats(
             JOIN tournaments t ON tr.tournament_id = t.id
             JOIN events e ON t.event_id = e.id
             WHERE tr.angler1_id {in_sql}
-              AND {year_col} >= 2023
+              AND {year_col} >= {TOURNAMENT_DATA_START_YEAR}
             UNION
             SELECT tr.angler2_id as angler_id, tr.tournament_id,
                    {year_col} as year
@@ -169,7 +170,7 @@ def get_member_stats(
             JOIN tournaments t ON tr.tournament_id = t.id
             JOIN events e ON t.event_id = e.id
             WHERE tr.angler2_id {in_sql}
-              AND {year_col} >= 2023
+              AND {year_col} >= {TOURNAMENT_DATA_START_YEAR}
         ) sub
         GROUP BY angler_id, year
     """
@@ -217,7 +218,7 @@ def get_member_monthly_weights(
                 JOIN events e ON t.event_id = e.id
                 WHERE r.angler_id {in_sql}
                   AND r.disqualified = FALSE
-                  AND {year_col} >= 2023
+                  AND {year_col} >= {TOURNAMENT_DATA_START_YEAR}
                 UNION ALL
                 -- Team results angler1 (only for tournaments without individual data)
                 SELECT tr.angler1_id as angler_id,
@@ -229,7 +230,7 @@ def get_member_monthly_weights(
                 JOIN tournaments t ON tr.tournament_id = t.id
                 JOIN events e ON t.event_id = e.id
                 WHERE tr.angler1_id {in_sql}
-                  AND {year_col} >= 2023
+                  AND {year_col} >= {TOURNAMENT_DATA_START_YEAR}
                   AND NOT EXISTS (SELECT 1 FROM results r WHERE r.tournament_id = t.id)
                 UNION ALL
                 -- Team results angler2 (only for tournaments without individual data, 0 weight)
@@ -243,7 +244,7 @@ def get_member_monthly_weights(
                 JOIN events e ON t.event_id = e.id
                 WHERE tr.angler2_id {in_sql}
                   AND tr.angler2_id IS NOT NULL
-                  AND {year_col} >= 2023
+                  AND {year_col} >= {TOURNAMENT_DATA_START_YEAR}
                   AND NOT EXISTS (SELECT 1 FROM results r WHERE r.tournament_id = t.id)
             )
             SELECT angler_id,
@@ -271,7 +272,7 @@ def get_member_monthly_weights(
                 JOIN events e ON t.event_id = e.id
                 WHERE r.angler_id = ANY(:member_ids)
                   AND r.disqualified = FALSE
-                  AND {year_col} >= 2023
+                  AND {year_col} >= {TOURNAMENT_DATA_START_YEAR}
                 UNION ALL
                 -- Team results angler1 (only for tournaments without individual data)
                 SELECT tr.angler1_id as angler_id,
@@ -283,7 +284,7 @@ def get_member_monthly_weights(
                 JOIN tournaments t ON tr.tournament_id = t.id
                 JOIN events e ON t.event_id = e.id
                 WHERE tr.angler1_id = ANY(:member_ids)
-                  AND {year_col} >= 2023
+                  AND {year_col} >= {TOURNAMENT_DATA_START_YEAR}
                   AND NOT EXISTS (SELECT 1 FROM results r WHERE r.tournament_id = t.id)
                 UNION ALL
                 -- Team results angler2 (only for tournaments without individual data, 0 weight)
@@ -297,7 +298,7 @@ def get_member_monthly_weights(
                 JOIN events e ON t.event_id = e.id
                 WHERE tr.angler2_id = ANY(:member_ids)
                   AND tr.angler2_id IS NOT NULL
-                  AND {year_col} >= 2023
+                  AND {year_col} >= {TOURNAMENT_DATA_START_YEAR}
                   AND NOT EXISTS (SELECT 1 FROM results r WHERE r.tournament_id = t.id)
             )
             SELECT angler_id,
@@ -316,7 +317,7 @@ def get_member_monthly_weights(
     member_weights: Dict[int, Dict[str, List[Dict[str, Any]]]] = {}
     for member_id in member_ids:
         member_weights[member_id] = {}
-        for year in range(2023, current_year + 1):
+        for year in range(TOURNAMENT_DATA_START_YEAR, current_year + 1):
             member_weights[member_id][str(year)] = [
                 {"weight": 0.0, "buy_in": False} for _ in range(12)
             ]


### PR DESCRIPTION
## Summary
Three small mechanical cleanups bundled. From the senior-pass audit: items #10, #11, #12.

## Changes

**[routes/pages/home.py:230](routes/pages/home.py#L230)** — kill the user dict-vs-object isinstance.
\`\`\`python
# Before
user_id = user.get(\"id\") if isinstance(user, dict) else user.id  # type: ignore[attr-defined]
# After
user_id = user.get(\"id\")
\`\`\`
\`get_user_optional()\` returns \`Optional[UserDict]\` — always a dict, never an ORM object. The defensive isinstance and the \`# type: ignore\` were both the type system telling us the abstraction was lying.

**13 hardcoded \`2023\` sites → \`TOURNAMENT_DATA_START_YEAR\` constant.**
- Added [core/enums.py](core/enums.py): \`TOURNAMENT_DATA_START_YEAR = 2023\` with a comment explaining what it represents.
- Replaced 6 sites in [routes/auth/profile.py](routes/auth/profile.py) (year iteration ranges, all-time finishes filter, three SQL fragments).
- Replaced 7 sites in [routes/pages/roster.py](routes/pages/roster.py) (member-stats init, four SQL fragments, monthly weights init).

If the club ever backfills pre-2023 data, it's now a one-line change instead of 13 grep-and-edits.

**[requirements-ci.txt](requirements-ci.txt)** — drop two dead DB drivers.
- \`aiosqlite==0.22.1\` — zero code references, zero test references. Pure dead weight.
- \`psycopg==3.3.4\` — zero direct references; production uses \`psycopg2-binary\` 2.9.12 in both prod and CI.

Verified by grep: neither package appears in \`routes/\`, \`core/\`, or \`tests/\`. Kept the SQLite dialect-helper branches in [core/query_service/dialect_helpers.py](core/query_service/dialect_helpers.py) and the call sites in profile/roster/tournament_queries — those are code, removing them is a separate (larger) refactor.

## Test plan
- [x] \`nix develop -c format-code\` — clean
- [x] \`nix develop -c check-code\` — ruff + mypy clean
- [x] \`nix develop -c run-tests\` — 974 passed, 1 skipped
- [ ] Smoke: load /profile (per-year stat blocks render correctly; monthly chart shows data from 2023)
- [ ] Smoke: load /roster (member stats per-year sections render)
- [ ] Smoke: log in and load the home page (the dropped \`isinstance(user, dict)\` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)