### PR TITLE
FIX: migrate TemplateResponse to new request-first signature (unblock CI)

### DIFF
--- a/routes/admin/core/dashboard.py
+++ b/routes/admin/core/dashboard.py
@@ -33,7 +33,7 @@ async def admin_page(request: Request, page: str, upcoming_page: int = 1, past_p
         raise HTTPException(status_code=404, detail=f"Admin page '{page}' not found")
 
     current_year = now_local().year
-    ctx: Dict[str, Any] = {"request": request, "user": user, "current_year": current_year}
+    ctx: Dict[str, Any] = {"user": user, "current_year": current_year}
     if page == "events":
         per_page = 20
         events, total_upcoming = get_upcoming_events_data(upcoming_page, per_page)
@@ -118,4 +118,4 @@ async def admin_page(request: Request, page: str, upcoming_page: int = 1, past_p
         ctx.update(get_users_data())
     elif page == "tournaments":
         ctx["tournaments"] = get_tournaments_data()
-    return templates.TemplateResponse(f"admin/{page}.html", ctx)
+    return templates.TemplateResponse(request, f"admin/{page}.html", ctx)

--- a/routes/admin/core/news.py
+++ b/routes/admin/core/news.py
@@ -47,9 +47,9 @@ async def admin_news(request: Request, show_archived: bool = False):
         news_items = news_query.all()
 
     return templates.TemplateResponse(
+        request,
         "admin/news.html",
         {
-            "request": request,
             "user": user,
             "news_items": news_items,
             "show_archived": show_archived,
@@ -157,9 +157,9 @@ async def edit_news_form(request: Request, news_id: int):
 
     # Return the admin news page with the news item data
     return templates.TemplateResponse(
+        request,
         "admin/news.html",
         {
-            "request": request,
             "user": user,
             "edit_news": news_item,
         },

--- a/routes/admin/events/create_event.py
+++ b/routes/admin/events/create_event.py
@@ -31,9 +31,9 @@ async def create_event_page(request: Request):
 
     # Reuse the events list template which has inline creation capability
     return templates.TemplateResponse(
+        request,
         "admin/events.html",
         {
-            "request": request,
             "user": user,
             "events": [],  # Empty list for create mode
             "create_mode": True,

--- a/routes/admin/events/update_event.py
+++ b/routes/admin/events/update_event.py
@@ -99,9 +99,9 @@ async def get_edit_event(request: Request, event_id: int):
             )
 
     return templates.TemplateResponse(
+        request,
         "admin/events.html",
         {
-            "request": request,
             "user": user,
             "edit_event_id": event_id,
             "current_year": now_local().year,

--- a/routes/admin/lakes/list_lakes.py
+++ b/routes/admin/lakes/list_lakes.py
@@ -25,7 +25,7 @@ async def admin_lakes(request: Request):
             for lake in lake_objs
         ]
     return templates.TemplateResponse(
-        "admin/lakes.html", {"request": request, "user": user, "lakes": lakes}
+        request, "admin/lakes.html", {"user": user, "lakes": lakes}
     )
 
 
@@ -56,9 +56,9 @@ async def edit_lake_page(request: Request, lake_id: int):
         ]
 
     return templates.TemplateResponse(
+        request,
         "admin/edit_lake.html",
         {
-            "request": request,
             "user": user,
             "lake": lake,
             "ramps": ramps,

--- a/routes/admin/polls/create_poll/form.py
+++ b/routes/admin/polls/create_poll/form.py
@@ -53,14 +53,13 @@ async def create_poll_form(request: Request, event_id: int = Query(None)):
                     )
 
         context = {
-            "request": request,
             "user": user,
             "events": events_list,
             "selected_event": selected_event,
             "lakes": lakes,
             "ramps": ramps,
         }
-        return templates.TemplateResponse("admin/create_poll.html", context)
+        return templates.TemplateResponse(request, "admin/create_poll.html", context)
     except SQLAlchemyError:
         return RedirectResponse(
             "/admin/events?error=Failed to load poll creation form", status_code=303

--- a/routes/admin/polls/edit_poll_form.py
+++ b/routes/admin/polls/edit_poll_form.py
@@ -38,7 +38,7 @@ async def edit_poll_form(request: Request, poll_id: int):
                 poll_obj.description,
             )
 
-            context = {"request": request, "user": user, "poll": poll}
+            context = {"user": user, "poll": poll}
 
             # Get poll options with vote counts
             with engine.connect() as conn:
@@ -70,9 +70,11 @@ async def edit_poll_form(request: Request, poll_id: int):
                             # Skip this option, continue with others
 
                 context["selected_lake_ids"] = selected_lake_ids
-                return templates.TemplateResponse("admin/edit_tournament_poll.html", context)
+                return templates.TemplateResponse(
+                    request, "admin/edit_tournament_poll.html", context
+                )
             else:
-                return templates.TemplateResponse("admin/edit_poll.html", context)
+                return templates.TemplateResponse(request, "admin/edit_poll.html", context)
 
     except SQLAlchemyError:
         return RedirectResponse("/polls?error=Failed to load poll", status_code=303)

--- a/routes/admin/tournaments/enter_results.py
+++ b/routes/admin/tournaments/enter_results.py
@@ -74,9 +74,9 @@ async def enter_results_page(
     is_team_format = not tournament.get("aoy_points", True)
 
     response = templates.TemplateResponse(
+        request,
         "admin/enter_results.html",
         {
-            "request": request,
             "user": user,
             "tournament": tournament,
             "anglers": anglers,

--- a/routes/admin/users/edit_user.py
+++ b/routes/admin/users/edit_user.py
@@ -45,9 +45,9 @@ async def edit_user_page(request: Request, user_id: int):
         current_officer_positions = [pos.position for pos in positions]
 
     return templates.TemplateResponse(
+        request,
         "admin/edit_user.html",
         {
-            "request": request,
             "user": user,
             "edit_user": edit_user,
             "current_officer_positions": current_officer_positions,

--- a/routes/admin/users/list_users.py
+++ b/routes/admin/users/list_users.py
@@ -31,9 +31,9 @@ async def admin_users(request: Request, user: AdminUser):
     guest_count = sum(1 for u in users if not u.get("member"))
     total_count = len(users)
     return templates.TemplateResponse(
+        request,
         "admin/users.html",
         {
-            "request": request,
             "user": user,
             "users": users,
             "active_member_count": active_member_count,

--- a/routes/admin/users/merge_accounts.py
+++ b/routes/admin/users/merge_accounts.py
@@ -25,8 +25,9 @@ async def merge_accounts_page(request: Request, user: AdminUser):
     anglers_sorted = sorted(anglers, key=lambda a: a.get("name", "").lower())
 
     return templates.TemplateResponse(
+        request,
         "admin/users/merge.html",
-        {"request": request, "user": user, "anglers": anglers_sorted},
+        {"user": user, "anglers": anglers_sorted},
     )
 
 
@@ -73,9 +74,9 @@ async def merge_execute(
 
         # Show success page with merge summary
         return templates.TemplateResponse(
+            request,
             "admin/users/merge_success.html",
             {
-                "request": request,
                 "user": user,
                 "result": result,
                 "source_id": source_id,

--- a/routes/auth/login.py
+++ b/routes/auth/login.py
@@ -62,9 +62,9 @@ async def login_page(request: Request) -> Response:
     next_url = request.query_params.get("next", "/")
 
     return templates.TemplateResponse(
+        request,
         "login.html",
         {
-            "request": request,
             "success": success,
             "error": error,
             "next_url": next_url,
@@ -99,8 +99,9 @@ async def login(
             extra={"user_email": email, "ip_address": ip_address},
         )
         return templates.TemplateResponse(
+            request,
             "login.html",
-            {"request": request, "error": "Too many failed attempts. Please try again later."},
+            {"error": "Too many failed attempts. Please try again later."},
         )
 
     try:
@@ -183,7 +184,7 @@ async def login(
         )
 
     return templates.TemplateResponse(
-        "login.html", {"request": request, "error": "Invalid email or password"}
+        request, "login.html", {"error": "Invalid email or password"}
     )
 
 

--- a/routes/auth/profile.py
+++ b/routes/auth/profile.py
@@ -374,9 +374,9 @@ async def profile_page(request: Request) -> Response:
         }
 
     return templates.TemplateResponse(
+        request,
         "profile.html",
         {
-            "request": request,
             "user": user_profile,
             "stats": stats,
             "current_year": current_year,

--- a/routes/auth/register.py
+++ b/routes/auth/register.py
@@ -24,7 +24,7 @@ async def register_page(request: Request) -> Response:
     return (
         RedirectResponse("/")
         if get_current_user(request)
-        else templates.TemplateResponse("register.html", {"request": request})
+        else templates.TemplateResponse(request, "register.html", {})
     )
 
 
@@ -34,7 +34,7 @@ async def register_page_auth(request: Request) -> Response:
     return (
         RedirectResponse("/")
         if get_current_user(request)
-        else templates.TemplateResponse("register.html", {"request": request})
+        else templates.TemplateResponse(request, "register.html", {})
     )
 
 
@@ -57,9 +57,9 @@ async def register(
     is_valid, error_message = validate_password_strength(password)
     if not is_valid:
         return templates.TemplateResponse(
+            request,
             "register.html",
             {
-                "request": request,
                 "error": error_message,
                 "first_name": first_name,
                 "last_name": last_name,
@@ -77,9 +77,9 @@ async def register(
                     extra={"user_email": email, "ip_address": ip_address},
                 )
                 return templates.TemplateResponse(
+                    request,
                     "register.html",
                     {
-                        "request": request,
                         "error": "Email already exists",
                         "first_name": first_name,
                         "last_name": last_name,
@@ -132,9 +132,9 @@ async def register(
             exc_info=True,
         )
         return templates.TemplateResponse(
+            request,
             "register.html",
             {
-                "request": request,
                 "error": "Registration failed",
                 "first_name": first_name,
                 "last_name": last_name,

--- a/routes/pages/awards.py
+++ b/routes/pages/awards.py
@@ -115,9 +115,9 @@ async def awards(request: Request, year: Optional[int] = None):
             team_wins = []
 
         return templates.TemplateResponse(
+            request,
             "awards.html",
             {
-                "request": request,
                 "user": user,
                 "current_year": year,
                 "available_years": years,

--- a/routes/pages/calendar.py
+++ b/routes/pages/calendar.py
@@ -38,9 +38,9 @@ async def calendar_page(request: Request) -> Response:
     all_event_types = current_event_types | next_event_types
 
     return templates.TemplateResponse(
+        request,
         "calendar.html",
         {
-            "request": request,
             "user": user,
             "current_year": current_year,
             "next_year": next_year,

--- a/routes/pages/data.py
+++ b/routes/pages/data.py
@@ -33,9 +33,9 @@ async def data_dashboard(
     tournament_participation = qs.get_tournament_participation()
 
     return templates.TemplateResponse(
+        request,
         "data.html",
         {
-            "request": request,
             "user": user,
             "available_years": available_years,
             "overview_stats": overview_stats,

--- a/routes/pages/home.py
+++ b/routes/pages/home.py
@@ -417,9 +417,9 @@ async def home_paginated(request: Request, page: int = 1):
     ]
 
     return templates.TemplateResponse(
+        request,
         "index.html",
         {
-            "request": request,
             "user": user,
             "all_tournaments": tournaments_with_results,
             "current_page": pagination.page,
@@ -618,9 +618,9 @@ async def contact_form(request: Request) -> RedirectResponse:
 async def static_page(request: Request, page: str):
     user = get_user_optional(request)
     if page in ["about", "bylaws"]:
-        context: Dict[str, Any] = {"request": request, "user": user}
+        context: Dict[str, Any] = {"user": user}
         if page == "about":
             context["form_loaded_at"] = str(int(time.time()))
             context["turnstile_site_key"] = TURNSTILE_SITE_KEY
-        return templates.TemplateResponse(f"{page}.html", context)
+        return templates.TemplateResponse(request, f"{page}.html", context)
     raise HTTPException(status_code=404, detail="Page not found")

--- a/routes/pages/roster.py
+++ b/routes/pages/roster.py
@@ -426,9 +426,9 @@ async def roster(request: Request) -> Any:
 
     user = get_user_optional(request)
     return templates.TemplateResponse(
+        request,
         "roster.html",
         {
-            "request": request,
             "user": user,
             "members": members,
             "member_weights": member_monthly_weights,

--- a/routes/password_reset/request_reset.py
+++ b/routes/password_reset/request_reset.py
@@ -28,7 +28,7 @@ limiter = Limiter(key_func=get_remote_address, enabled=not is_test_env)
 
 @router.get("/forgot-password")
 async def forgot_password_form(request: Request):
-    return templates.TemplateResponse("auth/forgot_password.html", {"request": request})
+    return templates.TemplateResponse(request, "auth/forgot_password.html", {})
 
 
 @router.post("/forgot-password")
@@ -79,4 +79,4 @@ async def request_password_reset(
 
 @router.get("/reset-password/help")
 async def password_reset_help(request: Request):
-    return templates.TemplateResponse("auth/password_reset_help.html", {"request": request})
+    return templates.TemplateResponse(request, "auth/password_reset_help.html", {})

--- a/routes/password_reset/reset_password.py
+++ b/routes/password_reset/reset_password.py
@@ -35,9 +35,9 @@ async def reset_password_form(
         success = request.query_params.get("success")
 
         return templates.TemplateResponse(
+            request,
             "auth/reset_password.html",
             {
-                "request": request,
                 "token": token,
                 "user_name": token_data["name"],
                 "expires_at": token_data["expires_at"],

--- a/routes/photos/gallery.py
+++ b/routes/photos/gallery.py
@@ -292,9 +292,9 @@ async def gallery(
         if is_htmx:
             # Return just the photo grid items for infinite scroll
             return templates.TemplateResponse(
+                request,
                 "photos/_photo_grid.html",
                 {
-                    "request": request,
                     "user": user,
                     "photos": photos,
                     "page": page,
@@ -325,9 +325,9 @@ async def gallery(
         angler_options = [{"id": a.id, "name": a.name} for a in anglers]
 
     return templates.TemplateResponse(
+        request,
         "photos/gallery.html",
         {
-            "request": request,
             "user": user,
             "photos": photos,
             "tournament_options": tournament_options,
@@ -367,9 +367,9 @@ async def upload_form(request: Request) -> Any:
         tournament_options = [{"id": t.id, "name": t.name} for t in tournaments]
 
     return templates.TemplateResponse(
+        request,
         "photos/upload.html",
         {
-            "request": request,
             "user": user,
             "tournament_options": tournament_options,
         },
@@ -555,9 +555,9 @@ async def edit_photo_form(request: Request, photo_id: int) -> Any:
         }
 
     return templates.TemplateResponse(
+        request,
         "photos/edit.html",
         {
-            "request": request,
             "user": user,
             "photo": photo_data,
             "tournament_options": tournament_options,

--- a/routes/tournaments/view.py
+++ b/routes/tournaments/view.py
@@ -70,9 +70,9 @@ async def tournament_results(request: Request, tournament_id: int, user: Optiona
             prev_tournament_id = qs.get_previous_tournament_id(tournament_id)
             year_links = qs.get_tournament_years_with_first_id(4)
             return templates.TemplateResponse(
+                request,
                 "tournament_results.html",
                 {
-                    "request": request,
                     "user": user,
                     "tournament": tournament_tuple,
                     "tournament_stats": stats_tuple,

--- a/routes/voting/list_polls.py
+++ b/routes/voting/list_polls.py
@@ -284,9 +284,9 @@ async def polls(
         for lake in get_lakes_list()
     ]
     return templates.TemplateResponse(
+        request,
         "polls.html",
         {
-            "request": request,
             "user": user,
             "polls": polls,
             "members": members_list,


### PR DESCRIPTION
## Summary
**Hotfix — master CI has been red since dependabot #297.** Unblocks PRs #302-#305.

## Root cause
[#297](https://github.com/envasquez/SABC/pull/297) (\"Bump the python-runtime-minor group with 45 updates\") upgraded fastapi 0.121.1 → 0.136.1 along with starlette and its mypy stubs. The new stubs require the request-first signature:

\`\`\`python
TemplateResponse(request, name, context, ...)
\`\`\`

The old form still works at runtime (emits a \`DeprecationWarning\`) but mypy fails on every call site — **78 errors across 24 files**. Master has been red since 19:08 UTC.

## Fix
Mechanical migration of 39 \`TemplateResponse\` call sites across 24 route files.

**Before:**
\`\`\`python
templates.TemplateResponse(\"login.html\", {\"request\": request, \"error\": error})
\`\`\`

**After:**
\`\`\`python
templates.TemplateResponse(request, \"login.html\", {\"error\": error})
\`\`\`

For each call: move \`request\` from inside the context dict to the first positional arg, drop the \`\"request\": request\` entry.

## Test plan
- [x] \`nix develop -c format-code\` — clean
- [x] \`nix develop -c check-code\` — ruff + mypy clean (down from 78 errors)
- [x] \`nix develop -c run-tests\` — 974 passed, 1 skipped
- [x] Pytest warning count dropped from 876 to 3 (deprecation warnings gone)
- [x] **Merge this first**, then the other 4 open PRs will pick up the fix on rebase and CI will go green for them too.

## Affected files (24)
auth/profile.py, auth/register.py, auth/login.py,
voting/list_polls.py,
admin/core/dashboard.py, admin/core/news.py,
admin/polls/edit_poll_form.py, admin/polls/create_poll/form.py,
admin/lakes/list_lakes.py,
admin/users/merge_accounts.py, admin/users/edit_user.py, admin/users/list_users.py,
admin/events/update_event.py, admin/events/create_event.py,
admin/tournaments/enter_results.py,
password_reset/reset_password.py, password_reset/request_reset.py,
photos/gallery.py,
tournaments/view.py,
pages/roster.py, pages/home.py, pages/awards.py, pages/calendar.py, pages/data.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)