### PR TITLE
fix: unblock master CI — ruff format + 3 tests for fastapi 0.136 Form() validation

### DIFF
--- a/routes/admin/lakes/list_lakes.py
+++ b/routes/admin/lakes/list_lakes.py
@@ -24,9 +24,7 @@ async def admin_lakes(request: Request):
             }
             for lake in lake_objs
         ]
-    return templates.TemplateResponse(
-        request, "admin/lakes.html", {"user": user, "lakes": lakes}
-    )
+    return templates.TemplateResponse(request, "admin/lakes.html", {"user": user, "lakes": lakes})
 
 
 @router.get("/admin/lakes/{lake_id}/edit")

--- a/routes/auth/login.py
+++ b/routes/auth/login.py
@@ -183,9 +183,7 @@ async def login(
             details={"reason": "system_error", "error": str(e)},
         )
 
-    return templates.TemplateResponse(
-        request, "login.html", {"error": "Invalid email or password"}
-    )
+    return templates.TemplateResponse(request, "login.html", {"error": "Invalid email or password"})
 
 
 @router.post("/logout")

--- a/tests/integration/test_event_deletion_password_reset.py
+++ b/tests/integration/test_event_deletion_password_reset.py
@@ -267,7 +267,11 @@ class TestPasswordResetRequest:
         self,
         client: TestClient,
     ):
-        """Test requesting password reset with empty email."""
+        """Empty email should fail. fastapi >= 0.133 rejects at the Form() layer
+        with 422 before the route runs; older versions accepted "" and the
+        route handler redirected 303 with ?error=... Either is a valid
+        rejection — assert the request didn't succeed.
+        """
         response = post_with_csrf(
             client,
             "/forgot-password",
@@ -275,8 +279,9 @@ class TestPasswordResetRequest:
             follow_redirects=False,
         )
 
-        assert response.status_code in [302, 303]
-        assert "error" in response.headers.get("location", "").lower()
+        assert response.status_code in [302, 303, 422]
+        if response.status_code in [302, 303]:
+            assert "error" in response.headers.get("location", "").lower()
 
     @patch("routes.password_reset.request_reset.send_password_reset_email")
     @patch("routes.password_reset.request_reset.create_password_reset_token")

--- a/tests/integration/test_event_management.py
+++ b/tests/integration/test_event_management.py
@@ -49,7 +49,10 @@ class TestEventCreationHelpers:
     def test_create_event_with_missing_required_fields_fails(
         self, admin_client: TestClient, db_session: Session
     ):
-        """Test that creating an event with missing required fields fails."""
+        """Empty `name` should fail. fastapi >= 0.133 rejects at Form() with
+        422 before the route runs; older versions accepted "" and the route
+        redirected 303 with ?error=... Either is a valid rejection.
+        """
         future_date = (now_local() + timedelta(days=30)).strftime("%Y-%m-%d")
 
         # Missing name
@@ -66,7 +69,7 @@ class TestEventCreationHelpers:
             follow_redirects=False,
         )
 
-        assert response.status_code in [302, 303]
+        assert response.status_code in [302, 303, 422]
 
     def test_create_event_with_invalid_lake_fails(
         self, admin_client: TestClient, db_session: Session
@@ -137,7 +140,10 @@ class TestEventUpdateErrors:
         test_event: Event,
         db_session: Session,
     ):
-        """Test that updating an event with missing required fields fails."""
+        """Empty `name` should fail. fastapi >= 0.133 rejects at Form() with
+        422 before the route runs; older versions accepted "" and the route
+        redirected 303 with ?error=... Either is a valid rejection.
+        """
         response = post_with_csrf(
             admin_client,
             f"/admin/events/{test_event.id}/update",
@@ -149,7 +155,7 @@ class TestEventUpdateErrors:
             follow_redirects=False,
         )
 
-        assert response.status_code in [302, 303]
+        assert response.status_code in [302, 303, 422]
 
     def test_update_event_with_invalid_foreign_key_fails(
         self,


### PR DESCRIPTION
## Summary
Two small fixes to unblock master CI. Both rooted in the fastapi 0.121 → 0.136 dependabot bump from #297.

## Changes

**1. \`ruff format\` line-length (2 files)**
The TemplateResponse migration in #306 left two call sites broken across multiple lines that ruff format wants on a single line (both fit under the 100-char limit):
- [routes/admin/lakes/list_lakes.py](routes/admin/lakes/list_lakes.py)
- [routes/auth/login.py](routes/auth/login.py)

Trivial whitespace-only collapse.

**2. Three tests assumed pre-0.133 Form() validation behavior**
\`test_request_password_reset_with_empty_email\`, \`test_create_event_with_missing_required_fields_fails\`, \`test_update_event_with_missing_required_fields_fails\` all post an empty-string value for a required Form field and assert the response is a 302/303 redirect with \`?error=...\` in the location.

fastapi >= 0.133 (which CI is now on) rejects empty values at the **Form() validation layer with 422** before the route handler runs. Older fastapi (which my local nix is still on) accepts \`""\` and lets the route handler redirect. The tests' intent — \"missing required fields fail\" — is satisfied in both versions; just different status codes.

Loosened the assertions to \`in [302, 303, 422]\` so they pass under either fastapi behavior. Once nix bumps to 0.136 and behavior unifies, we can tighten back to a single expected code.

## Test plan
- [x] \`nix develop -c format-code\` — clean
- [x] \`nix develop -c check-code\` — ruff + mypy clean
- [x] \`nix develop -c run-tests\` — 974 passed, 1 skipped, 3 warnings
- [ ] CI green on this PR
- [ ] After merge: master CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)