### PR TITLE
Small fixes: utils.js cache-bust, explicit session security, gallery.py Session type

### DIFF
--- a/app_setup.py
+++ b/app_setup.py
@@ -93,7 +93,15 @@ def create_app() -> FastAPI:
 
     app.add_middleware(SecurityHeadersMiddleware)
 
-    # Session middleware with secure configuration
+    # Session middleware with secure configuration.
+    # Note: Starlette's SessionMiddleware always sets HttpOnly on the session
+    # cookie (it has no kwarg to disable it), so HttpOnly is implicit-by-default
+    # and is reviewable in the upstream source. We make same_site, max_age, and
+    # https_only explicit here so the security posture is auditable in-tree.
+    # https_only is enabled for every environment that is NOT dev/test — this
+    # mirrors the _DEV_SECRET_FALLBACK_ENVS allowlist above so a misspelled or
+    # new ENVIRONMENT value (e.g. "staging") gets the tighter posture by default
+    # rather than silently falling back to insecure cookies.
     secret_key = _get_secret_key()
     app.add_middleware(
         SessionMiddleware,
@@ -101,7 +109,7 @@ def create_app() -> FastAPI:
         session_cookie="sabc_session",
         max_age=int(os.environ.get("SESSION_TIMEOUT", "86400")),  # Default 24 hours
         same_site="lax",  # "lax" for better compatibility, "strict" for maximum security
-        https_only=os.environ.get("ENVIRONMENT", "development") == "production",
+        https_only=os.environ.get("ENVIRONMENT", "development") not in _DEV_SECRET_FALLBACK_ENVS,
     )
 
     # CSRF protection middleware (disabled in test environment to simplify testing).

--- a/routes/photos/gallery.py
+++ b/routes/photos/gallery.py
@@ -12,6 +12,7 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy import or_
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Query, Session
 
 from core.db_schema import Angler, Event, Photo, TeamResult, Tournament, get_session
 from core.helpers.auth import get_current_user, require_member
@@ -176,12 +177,18 @@ def can_edit_photo(user: UserDict, photo: Photo) -> bool:
 
 
 def build_photo_query(
-    session: Any,
+    session: Session,
     tournament_id_int: Optional[int],
     angler_id_int: Optional[int],
     big_bass_bool: Optional[bool],
-) -> Any:
-    """Build the base query for photos with filters."""
+) -> "Query[Any]":
+    """Build the base query for photos with filters.
+
+    Returns Query[Any] because the underlying query selects a 3-tuple
+    (Photo, Angler, Tournament) — there is no single row type to parametrise
+    Query with. The Session parameter is now explicit so callers get type
+    checking on the session they pass in.
+    """
     query = (
         session.query(Photo, Angler, Tournament)
         .join(Angler, Photo.angler_id == Angler.id)

--- a/templates/base.html
+++ b/templates/base.html
@@ -153,7 +153,7 @@
 
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/static/utils.js"></script>
+    <script src="/static/utils.js?v=1"></script>
     {% block extra_js %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Three trivial, behavior-preserving fixes bundled into one PR (PR A of a 5-PR refactor series).

## Fix 1 — `templates/base.html`: cache-bust `utils.js`

Added `?v=1` to `/static/utils.js`. CSS on line 10 already uses `?v=11`; per the standing rule, the first JS cache-bust value just needs to exist so future edits can bump it.

**Rationale:** Without a cache-bust param, browsers will silently serve stale `utils.js` after a deploy. Adding the param now means the next JS change can just bump to `?v=2` without a separate "introduce cache-bust" commit.

## Fix 2 — `app_setup.py`: explicit `SessionMiddleware` security

Aligned the `https_only` flag with the existing `_DEV_SECRET_FALLBACK_ENVS` allowlist (the same one `_get_secret_key()` uses).

**Before:** `https_only=os.environ.get("ENVIRONMENT", "development") == "production"`
**After:** `https_only=os.environ.get("ENVIRONMENT", "development") not in _DEV_SECRET_FALLBACK_ENVS`

**Behavior delta:**
- `ENVIRONMENT=production` → identical (`https_only=True`)
- `ENVIRONMENT=development` → identical (`https_only=False`)
- `ENVIRONMENT=test` → identical (`https_only=False`)
- `ENVIRONMENT=staging` or unset-but-not-default → now `https_only=True` (was `False`)

This mirrors the security-trio PR (#302) intent: misspelled or unknown environment values should fail closed (secure), not open (insecure). Documented inline that HttpOnly is implicit because Starlette's `SessionMiddleware` hardcodes it and has no kwarg to disable.

## Fix 3 — `routes/photos/gallery.py`: type `build_photo_query` parameter

Replaced `session: Any` → `session: Session` and `-> Any` → `-> Query[Any]`.

**Rationale:** Eliminates `Any` propagation through the photos gallery query pipeline. `Query[Any]` (not `Query[Photo]`) is the accurate annotation because the underlying `.query(Photo, Angler, Tournament)` returns a 3-tuple per row. No logic touched.

## Verification

Per `CLAUDE.md` §0, ran the mandatory three commands inside `nix develop`:

| Command | Result |
|---|---|
| `nix develop -c format-code` | Pass — 257 files unchanged; all ruff auto-fix checks passed |
| `nix develop -c check-code`  | Ruff clean; mypy reports 12 pre-existing `alembic.op` `attr-defined` errors (verified identical on clean master via `git stash` — **unrelated to this PR**) |
| `nix develop -c run-tests`   | Blocked by pre-existing missing `slowapi` dep in `flake.nix` (verified reproducible on clean master via `git stash` — **unrelated to this PR; nix-shell env-config gap**). CI uses `pip install -r requirements-ci.txt` which has `slowapi==0.1.9`, so CI tests will run correctly. |

## Risk

**None — behavior-preserving.**

- Fix 1 is a single-character URL change; the asset content is unchanged.
- Fix 2 leaves production, development, and test behavior bit-identical; only changes posture for misspelled `ENVIRONMENT` values (a security improvement, not a regression).
- Fix 3 is annotation-only; no runtime semantics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)