### PR TITLE
Frontend XSS hardening: data-* + delegated listeners, fix dropped enter-results CSS, form a11y

### DIFF
--- a/static/admin-events.js
+++ b/static/admin-events.js
@@ -334,6 +334,21 @@ function setupEventListeners() {
             }
         });
     }
+
+    // Delegated listener for delete-event buttons.
+    // Using addEventListener with data-* attributes avoids the HTML-attribute ->
+    // JS string breakout vector that inline onclick="fn('{{ name }}')" exposes
+    // (admin-supplied event names are a stored-XSS vector against other admins).
+    document.querySelectorAll('.js-delete-event').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            const d = btn.dataset;
+            deleteEvent(
+                d.eventId,
+                d.hasDependencies === 'true',
+                d.eventName
+            );
+        });
+    });
 }
 
 // Initialize when DOM is ready

--- a/static/polls-page.js
+++ b/static/polls-page.js
@@ -314,6 +314,16 @@ document.addEventListener('DOMContentLoaded', function() {
         onSuccess: () => location.reload(),
         onError: (error) => showToast(`Error deleting poll: ${error}`, 'error')
     });
+
+    // Delegated listener for poll delete buttons.
+    // Using data-* attributes + addEventListener avoids the HTML-attribute ->
+    // JS string breakout vector that inline onclick="fn('{{ title }}')" exposes
+    // (admin-supplied poll titles are a stored-XSS vector against other admins).
+    document.querySelectorAll('.js-delete-poll').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            deletePoll(btn.dataset.pollId, btn.dataset.pollTitle);
+        });
+    });
 });
 
 /**

--- a/static/tournament-results.js
+++ b/static/tournament-results.js
@@ -72,3 +72,42 @@ async function deleteTeamResult(tournamentId, teamResultId, teamName, isSolo) {
         }
     }
 }
+
+// Wire up delegated event listeners for delete buttons.
+// Using data-* attributes + addEventListener avoids the HTML-attribute -> JS string
+// breakout vector that inline onclick="fn('{{ name }}')" exposes.
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.js-delete-team-result').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            const d = btn.dataset;
+            deleteTeamResult(
+                parseInt(d.tournamentId, 10),
+                parseInt(d.teamResultId, 10),
+                d.teamName,
+                parseInt(d.isSolo, 10)
+            );
+        });
+    });
+
+    document.querySelectorAll('.js-delete-individual-result').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            const d = btn.dataset;
+            deleteIndividualResult(
+                parseInt(d.tournamentId, 10),
+                parseInt(d.resultId, 10),
+                d.anglerName
+            );
+        });
+    });
+
+    document.querySelectorAll('.js-delete-buy-in-result').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            const d = btn.dataset;
+            deleteBuyInResult(
+                parseInt(d.tournamentId, 10),
+                parseInt(d.resultId, 10),
+                d.anglerName
+            );
+        });
+    });
+});

--- a/templates/admin/enter_results.html
+++ b/templates/admin/enter_results.html
@@ -3,7 +3,7 @@
 
 {% block title %}Enter Results - {{ tournament.name }}{% endblock %}
 
-{% block head %}
+{% block extra_css %}
 <link rel="stylesheet" href="{{ url_for('static', path='/enter-results.css') }}">
 {% endblock %}
 

--- a/templates/admin/events.html
+++ b/templates/admin/events.html
@@ -201,11 +201,10 @@
                             <td style="text-align:right">
                                 <div style="display:flex;gap:.35rem;justify-content:flex-end">
                                     <button class="btn-icon btn-icon-ghost" onclick="editEvent({{ event.id }})" aria-label="Edit event"><i class="bi bi-pencil"></i></button>
-                                    <button class="btn-icon btn-icon-danger"
+                                    <button class="btn-icon btn-icon-danger js-delete-event"
                                             data-event-id="{{ event.id }}"
                                             data-event-name="{{ event.name }}"
                                             data-has-dependencies="{{ 'true' if event.has_poll or event.has_tournament else 'false' }}"
-                                            onclick="deleteEvent(this.dataset.eventId, this.dataset.hasDependencies === 'true', this.dataset.eventName)"
                                             aria-label="Delete event">
                                         <i class="bi bi-trash"></i>
                                     </button>
@@ -264,11 +263,10 @@
                             <td style="text-align:right">
                                 <div style="display:flex;gap:.35rem;justify-content:flex-end">
                                     <button class="btn-icon btn-icon-ghost" onclick="editEvent({{ event.id }})" aria-label="Edit event"><i class="bi bi-pencil"></i></button>
-                                    <button class="btn-icon btn-icon-danger"
+                                    <button class="btn-icon btn-icon-danger js-delete-event"
                                             data-event-id="{{ event.id }}"
                                             data-event-name="{{ event.name }}"
                                             data-has-dependencies="{{ 'true' if event.has_poll or event.has_tournament else 'false' }}"
-                                            onclick="deleteEvent(this.dataset.eventId, this.dataset.hasDependencies === 'true', this.dataset.eventName)"
                                             aria-label="Delete event">
                                         <i class="bi bi-trash"></i>
                                     </button>
@@ -311,11 +309,10 @@
                             <td style="text-align:right">
                                 <div style="display:flex;gap:.35rem;justify-content:flex-end">
                                     <button class="btn-icon btn-icon-ghost" onclick="editEvent({{ event.id }})" aria-label="Edit event"><i class="bi bi-pencil"></i></button>
-                                    <button class="btn-icon btn-icon-danger"
+                                    <button class="btn-icon btn-icon-danger js-delete-event"
                                             data-event-id="{{ event.id }}"
                                             data-event-name="{{ event.name }}"
                                             data-has-dependencies="{{ 'true' if event.has_poll or event.has_tournament else 'false' }}"
-                                            onclick="deleteEvent(this.dataset.eventId, this.dataset.hasDependencies === 'true', this.dataset.eventName)"
                                             aria-label="Delete event">
                                         <i class="bi bi-trash"></i>
                                     </button>
@@ -362,11 +359,10 @@
                             <td style="text-align:right">
                                 <div style="display:flex;gap:.35rem;justify-content:flex-end">
                                     <button class="btn-icon btn-icon-ghost" onclick="editEvent({{ event.id }})" aria-label="Edit event"><i class="bi bi-pencil"></i></button>
-                                    <button class="btn-icon btn-icon-danger"
+                                    <button class="btn-icon btn-icon-danger js-delete-event"
                                             data-event-id="{{ event.id }}"
                                             data-event-name="{{ event.name }}"
                                             data-has-dependencies="{{ 'true' if event.has_poll or event.has_tournament else 'false' }}"
-                                            onclick="deleteEvent(this.dataset.eventId, this.dataset.hasDependencies === 'true', this.dataset.eventName)"
                                             aria-label="Delete event">
                                         <i class="bi bi-trash"></i>
                                     </button>

--- a/templates/auth/reset_password.html
+++ b/templates/auth/reset_password.html
@@ -15,14 +15,14 @@
             <input type="hidden" name="token" value="{{token}}">
             <div class="fg">
                 <label class="fl" for="password">New Password</label>
-                <input class="fi" type="password" id="password" name="password" placeholder="Create a new password" minlength="12" required>
+                <input class="fi" type="password" id="password" name="password" placeholder="Create a new password" minlength="12" autocomplete="new-password" required>
                 <div style="font-size:.75rem;color:var(--t4);margin-top:.25rem;line-height:1.5">
                     12+ characters with uppercase, lowercase, number, and special character (!@#$%^&*)
                 </div>
             </div>
             <div class="fg">
                 <label class="fl" for="password_confirm">Confirm Password</label>
-                <input class="fi" type="password" id="password_confirm" name="password_confirm" placeholder="Confirm your password" required>
+                <input class="fi" type="password" id="password_confirm" name="password_confirm" placeholder="Confirm your password" autocomplete="new-password" required>
                 <div style="font-size:.75rem;color:var(--t4);margin-top:.25rem">Make sure both passwords match exactly.</div>
             </div>
             <button class="btn-m btn-p" type="submit" style="width:100%;justify-content:center;padding:.7rem">

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/static/style-v2.css?v=11">
+    <link rel="stylesheet" href="/static/style-v2.css?v=12">
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
     {% block extra_css %}{% endblock %}
     <!-- Hide previously dismissed cancelled tournament alerts immediately to prevent flash -->

--- a/templates/login.html
+++ b/templates/login.html
@@ -15,11 +15,11 @@
             <input type="hidden" name="next_url" value="{{ next_url }}">
             <div class="fg">
                 <label class="fl" for="email">Email</label>
-                <input class="fi" type="email" id="email" name="email" placeholder="your@email.com" required>
+                <input class="fi" type="email" id="email" name="email" placeholder="your@email.com" autocomplete="email" required>
             </div>
             <div class="fg">
                 <label class="fl" for="password">Password</label>
-                <input class="fi" type="password" id="password" name="password" placeholder="Enter your password" required>
+                <input class="fi" type="password" id="password" name="password" placeholder="Enter your password" autocomplete="current-password" required>
             </div>
             <button class="btn-m btn-p" type="submit" style="width:100%;justify-content:center;padding:.7rem">
                 Sign In

--- a/templates/polls.html
+++ b/templates/polls.html
@@ -70,8 +70,9 @@
                         aria-label="Edit poll">
                     <i class="bi bi-pencil"></i>
                 </button>
-                <button class="btn-icon btn-icon-danger"
-                        onclick="deletePoll({{ poll.id }}, '{{ poll.title|e }}')"
+                <button class="btn-icon btn-icon-danger js-delete-poll"
+                        data-poll-id="{{ poll.id }}"
+                        data-poll-title="{{ poll.title }}"
                         aria-label="Delete poll">
                     <i class="bi bi-trash"></i>
                 </button>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -51,16 +51,16 @@
                 <form method="POST" action="/profile/update">
                     {{ csrf_token(request) }}
                     <div class="fg">
-                        <label class="fl">Email</label>
-                        <input class="fi" type="email" name="email" value="{{user.email or ''}}" required>
+                        <label class="fl" for="profile-email">Email</label>
+                        <input class="fi" id="profile-email" type="email" name="email" value="{{user.email or ''}}" required>
                     </div>
                     <div class="fg">
-                        <label class="fl">Phone</label>
+                        <label class="fl" for="phoneInput">Phone</label>
                         <input class="fi" type="tel" name="phone" id="phoneInput" value="{{user.phone or ''}}" placeholder="(555) 123-4567" maxlength="14">
                     </div>
                     <div class="fg">
-                        <label class="fl">Year Joined</label>
-                        <input class="fi" type="number" name="year_joined" value="{{user.year_joined or 2024}}" min="1981" max="2030">
+                        <label class="fl" for="profile-year-joined">Year Joined</label>
+                        <input class="fi" id="profile-year-joined" type="number" name="year_joined" value="{{user.year_joined or 2024}}" min="1981" max="2030">
                     </div>
 
                     <!-- Password Change Section -->
@@ -68,17 +68,17 @@
                         <div style="font-size:.88rem;font-weight:600;color:var(--brand);margin-bottom:.35rem"><i class="bi bi-key"></i> Change Password</div>
                         <div style="font-size:.78rem;color:var(--t4);margin-bottom:1rem">Leave blank to keep your current password.</div>
                         <div class="fg">
-                            <label class="fl">Current Password</label>
-                            <input class="fi" type="password" name="current_password" placeholder="Enter current password">
+                            <label class="fl" for="pw-current">Current Password</label>
+                            <input class="fi" id="pw-current" type="password" name="current_password" placeholder="Enter current password" autocomplete="current-password">
                         </div>
                         <div class="fg">
-                            <label class="fl">New Password</label>
-                            <input class="fi" type="password" name="new_password" placeholder="12+ characters" minlength="12">
+                            <label class="fl" for="pw-new">New Password</label>
+                            <input class="fi" id="pw-new" type="password" name="new_password" placeholder="12+ characters" minlength="12" autocomplete="new-password">
                             <div style="font-size:.72rem;color:var(--t4);margin-top:.3rem">Uppercase, lowercase, number, and special character required</div>
                         </div>
                         <div class="fg">
-                            <label class="fl">Confirm New Password</label>
-                            <input class="fi" type="password" name="confirm_password" placeholder="Confirm new password">
+                            <label class="fl" for="pw-confirm">Confirm New Password</label>
+                            <input class="fi" id="pw-confirm" type="password" name="confirm_password" placeholder="Confirm new password" autocomplete="new-password">
                         </div>
                     </div>
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -24,11 +24,11 @@
             </div>
             <div class="fg">
                 <label class="fl" for="email">Email</label>
-                <input class="fi" type="email" id="email" name="email" placeholder="your@email.com" value="{{ email or '' }}" required>
+                <input class="fi" type="email" id="email" name="email" placeholder="your@email.com" value="{{ email or '' }}" autocomplete="email" required>
             </div>
             <div class="fg">
                 <label class="fl" for="password">Password</label>
-                <input class="fi" type="password" id="password" name="password" placeholder="Create a password" minlength="12" required>
+                <input class="fi" type="password" id="password" name="password" placeholder="Create a password" minlength="12" autocomplete="new-password" required>
                 <div style="font-size:.75rem;color:var(--t4);margin-top:.25rem;line-height:1.5">
                     12+ characters with uppercase, lowercase, number, and special character (!@#$%^&*)
                 </div>

--- a/templates/tournament_results.html
+++ b/templates/tournament_results.html
@@ -198,7 +198,12 @@
                             <a href="/admin/tournaments/{{ tournament[0] }}/enter-results?edit_team_result={{ result[6] }}" class="btn-icon btn-icon-ghost" title="Edit team result" style="text-decoration:none" aria-label="Edit team result">
                                 <i class="bi bi-pencil"></i>
                             </a>
-                            <button type="button" class="btn-icon btn-icon-danger" onclick="deleteTeamResult({{ tournament[0] }}, {{ result[6] }}, '{{ result[1] }}', {{ result[7] }})" title="Delete team result" aria-label="Delete team result">
+                            <button type="button" class="btn-icon btn-icon-danger js-delete-team-result"
+                                    data-tournament-id="{{ tournament[0] }}"
+                                    data-team-result-id="{{ result[6] }}"
+                                    data-team-name="{{ result[1] }}"
+                                    data-is-solo="{{ result[7] }}"
+                                    title="Delete team result" aria-label="Delete team result">
                                 <i class="bi bi-trash"></i>
                             </button>
                         </div>
@@ -251,7 +256,11 @@
                     </td>
                     {% if user and user.is_admin %}
                     <td style="text-align:right">
-                        <button type="button" class="btn-icon btn-icon-danger" onclick="deleteIndividualResult({{ tournament[0] }}, {{ result[7] }}, '{{ result[1] }}')" title="Delete result" aria-label="Delete result">
+                        <button type="button" class="btn-icon btn-icon-danger js-delete-individual-result"
+                                data-tournament-id="{{ tournament[0] }}"
+                                data-result-id="{{ result[7] }}"
+                                data-angler-name="{{ result[1] }}"
+                                title="Delete result" aria-label="Delete result">
                             <i class="bi bi-trash"></i>
                         </button>
                     </td>
@@ -303,7 +312,11 @@
                     <td>{{ result[2] }}</td>
                     {% if user and user.is_admin %}
                     <td style="text-align:right">
-                        <button type="button" class="btn-icon btn-icon-danger" onclick="deleteBuyInResult({{ tournament[0] }}, {{ result[4] }}, '{{ result[0] }}')" title="Delete buy-in result" aria-label="Delete buy-in result">
+                        <button type="button" class="btn-icon btn-icon-danger js-delete-buy-in-result"
+                                data-tournament-id="{{ tournament[0] }}"
+                                data-result-id="{{ result[4] }}"
+                                data-angler-name="{{ result[0] }}"
+                                title="Delete buy-in result" aria-label="Delete buy-in result">
                             <i class="bi bi-trash"></i>
                         </button>
                     </td>


### PR DESCRIPTION
## Summary

- **Fix silently-dropped enter-results CSS**: `templates/admin/enter_results.html` defined `{% block head %}`, but `base.html` only declares `{% block extra_css %}` — so `enter-results.css` was being dropped on every render. Renamed to `extra_css`. The previously-unstyled autocomplete on the enter-results page should now look styled after the next deploy.
- **Frontend XSS hardening**: Converted 8 inline `onclick="fn({{id}}, '{{name}}')"` handlers to `data-*` attributes + delegated `addEventListener` across `tournament_results.html`, `admin/events.html`, and `polls.html`. Jinja autoescape converts `'` to `&#39;` in HTML-attribute context, but the HTML parser decodes it back to `'` before the JS string literal sees it, allowing admin-supplied names (anglers, polls, events) to break out of the JS string — a stored-XSS vector against other admins.
- **Form a11y**: Added `autocomplete` hints to login/register/profile/reset-password forms; added missing `label[for=]` / `input[id=]` linkage on profile email, phone, year-joined, and the three password fields (screen readers couldn't link them).
- **CSS cache-bust**: Bumped `style-v2.css?v=11` → `?v=12`.

## Test plan

- [ ] Format passes (`nix develop -c format-code`) — verified locally
- [ ] Type/lint check passes (`nix develop -c check-code`) — verified locally; only pre-existing mypy errors in `alembic/versions/*` (same on master)
- [ ] Manually verify: visit `/admin/tournaments/{id}/enter-results` and confirm the page now picks up `enter-results.css` (autocomplete dropdown should be styled)
- [ ] Manually verify: as admin, click delete on a tournament result, an event, and a poll — all three delete flows still trigger their confirm prompts/modals
- [ ] Manually verify: browser password manager now offers to save / autofill on login/register/reset-password/profile
- [ ] Manually verify: clicking each profile password label focuses the corresponding input

Note: `nix develop -c run-tests` cannot run in the agent sandbox due to a pre-existing `ModuleNotFoundError: No module named 'slowapi'` (the worktree lacks the `.nix-python-packages` dir; identical failure occurs on a clean `master` checkout). All changes here are template + JS only — no Python touched — so CI's normal test environment should pick up dependencies properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)