### PR TITLE
Speed up test suite: 8.5min -> ~40s

### DIFF
--- a/core/helpers/passwords.py
+++ b/core/helpers/passwords.py
@@ -1,0 +1,17 @@
+"""Password hashing helpers."""
+
+import os
+
+import bcrypt
+
+
+def bcrypt_gensalt() -> bytes:
+    """Generate a bcrypt salt.
+
+    The work factor defaults to 12 (production-grade strength). The test suite
+    sets ``BCRYPT_ROUNDS=4`` to keep hashing and verification fast — bcrypt
+    encodes the cost inside the hash, so a low-cost test hash is also cheap to
+    verify. This must never be lowered in a production environment.
+    """
+    rounds = int(os.environ.get("BCRYPT_ROUNDS", "12"))
+    return bcrypt.gensalt(rounds=rounds)

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
           # Testing
           pytest
           pytest-cov
+          pytest-xdist  # Parallel test execution (-n auto)
           httpx  # Required by FastAPI TestClient
 
           # Development tools
@@ -161,40 +162,25 @@ print('Database reset complete!')
           echo "=========================="
           echo ""
 
-          # Set test database URL
-          export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/sabc_test"
-
-          # Check if PostgreSQL container is running
-          if ! docker ps | grep -q sabc-postgres; then
-              echo "⚠️  PostgreSQL container not running. Starting it..."
-              docker compose -f docker-compose.dev.yml up -d postgres
-              echo "Waiting for PostgreSQL to be ready..."
-              until docker compose -f docker-compose.dev.yml exec postgres pg_isready -U postgres; do
-                sleep 1
-              done
-              echo "✓ PostgreSQL is ready!"
-          fi
-
-          # Create test database using Docker exec
-          echo "📦 Setting up test database..."
-          docker exec sabc-postgres psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'sabc_test'" | grep -q 1 || \
-              docker exec sabc-postgres psql -U postgres -c "CREATE DATABASE sabc_test"
-
-          echo "✅ Test database ready"
-          echo ""
+          # Tests use file-based SQLite, configured in tests/conftest.py — no
+          # external PostgreSQL is required. Clear any stale per-worker DB files
+          # left behind by a previous (possibly interrupted) parallel run.
+          rm -f test_sabc*.db test_sabc*.db-journal test_sabc*.db-wal test_sabc*.db-shm
 
           # Run pytest with any arguments passed
           if [ "$1" == "--coverage" ]; then
+              shift
               echo "📊 Running tests with coverage..."
-              pytest tests/ --cov=core --cov=routes --cov-report=html --cov-report=term
+              pytest tests/ --cov=core --cov=routes --cov-report=html --cov-report=term --cov-report=xml --cov-fail-under=70 "$@"
               echo ""
               echo "📄 Coverage report saved to: htmlcov/index.html"
           elif [ "$1" == "--smoke" ]; then
+              shift
               echo "💨 Running smoke tests only..."
-              pytest tests/test_routes_smoke.py -v "$@"
+              pytest tests/test_routes_smoke.py "$@"
           else
               echo "🧪 Running tests..."
-              pytest tests/ -v "$@"
+              pytest tests/ "$@"
           fi
 
           echo ""

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,19 +6,16 @@ python_classes = Test*
 python_functions = test_*
 
 # Options
+# Coverage is intentionally NOT enabled here — it adds ~20-40% overhead on
+# every run. Pass --cov explicitly (CI does; `run-tests --coverage` does).
+# -n auto runs the suite in parallel across CPU cores via pytest-xdist.
 addopts =
-    -v
     -ra
-    --showlocals
     --tb=short
     --strict-markers
     --disable-warnings
-    --cov=.
-    --cov-report=html
-    --cov-report=term-missing
-    --cov-report=xml
-    --cov-fail-under=70
     --color=yes
+    -n auto
 
 # Async test configuration
 asyncio_default_fixture_loop_scope = function

--- a/routes/auth/login.py
+++ b/routes/auth/login.py
@@ -13,6 +13,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from core.db_schema import Angler, get_session
 from core.helpers.forms import normalize_email
 from core.helpers.logging import SecurityEvent, get_logger, log_security_event
+from core.helpers.passwords import bcrypt_gensalt
 from core.helpers.response import get_client_ip, get_safe_redirect_url, set_user_session
 from routes.dependencies import bcrypt, get_current_user, templates
 
@@ -145,7 +146,7 @@ async def login(
                 user_session_version = angler.session_version
             else:
                 # User doesn't exist - perform dummy hash to prevent timing attack
-                stored_hash = bcrypt.hashpw(b"dummy_password", bcrypt.gensalt())
+                stored_hash = bcrypt.hashpw(b"dummy_password", bcrypt_gensalt())
                 user_id = None
                 user_name = None
                 user_session_version = 1

--- a/routes/auth/profile_update/password.py
+++ b/routes/auth/profile_update/password.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple
 from core.db_schema import Angler, get_session
 from core.helpers.logging import SecurityEvent, get_logger, log_security_event
 from core.helpers.password_validator import validate_password_strength
+from core.helpers.passwords import bcrypt_gensalt
 from core.types import UserDict
 from routes.dependencies import bcrypt
 
@@ -48,7 +49,7 @@ def handle_password_change(
         ):
             return False, "Current password is incorrect", None
 
-        new_password_hash = bcrypt.hashpw(new_password.encode("utf-8"), bcrypt.gensalt()).decode(
+        new_password_hash = bcrypt.hashpw(new_password.encode("utf-8"), bcrypt_gensalt()).decode(
             "utf-8"
         )
 

--- a/routes/auth/register.py
+++ b/routes/auth/register.py
@@ -10,6 +10,7 @@ from core.db_schema import Angler, get_session
 from core.helpers.forms import normalize_email
 from core.helpers.logging import SecurityEvent, get_logger, log_security_event
 from core.helpers.password_validator import validate_password_strength
+from core.helpers.passwords import bcrypt_gensalt
 from core.helpers.response import set_user_session
 from routes.dependencies import bcrypt, get_current_user, templates
 
@@ -89,7 +90,7 @@ async def register(
                 )
 
             # Create new angler
-            password_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+            password_hash = bcrypt.hashpw(password.encode(), bcrypt_gensalt()).decode()
             new_angler = Angler(
                 name=name,
                 email=email,

--- a/routes/password_reset/reset_password.py
+++ b/routes/password_reset/reset_password.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from core.db_schema import Angler, get_session
 from core.email import use_reset_token, verify_reset_token
 from core.helpers.logging import SecurityEvent, get_logger, log_security_event
+from core.helpers.passwords import bcrypt_gensalt
 from core.helpers.response import error_redirect
 from routes.dependencies import templates
 from routes.password_reset.reset_validation import (
@@ -73,7 +74,7 @@ async def process_password_reset(
         if not token_data:
             return error_redirect("/forgot-password", ERROR_INVALID_TOKEN)
 
-        password_hash = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+        password_hash = bcrypt.hashpw(password.encode("utf-8"), bcrypt_gensalt()).decode("utf-8")
 
         with get_session() as session:
             angler = session.query(Angler).filter(Angler.id == token_data["user_id"]).first()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,14 +3,23 @@
 import os
 
 # CRITICAL: Set test database URL BEFORE any imports
-# This must happen before core.db_schema.engine imports and creates the engine
-# Use file-based SQLite so multiple engines can share the same database
-TEST_DATABASE_URL = "sqlite:///test_sabc.db"  # File-based SQLite for tests
+# This must happen before core.db_schema.engine imports and creates the engine.
+# File-based SQLite (not :memory:) is used so the app's engine and the test
+# engine — two engines built from DATABASE_URL — share one database.
+# Each pytest-xdist worker gets its own file so parallel workers stay isolated;
+# PYTEST_XDIST_WORKER is "main" when running without xdist.
+_worker_id = os.environ.get("PYTEST_XDIST_WORKER", "main")
+TEST_DATABASE_URL = f"sqlite:///test_sabc_{_worker_id}.db"
 os.environ["DATABASE_URL"] = TEST_DATABASE_URL
 os.environ["ENVIRONMENT"] = "test"
 os.environ["SECRET_KEY"] = "test-secret-key-for-testing-only-minimum-32-characters-long"
 os.environ["DEBUG"] = "false"
 os.environ["LOG_LEVEL"] = "ERROR"
+# Use the minimum bcrypt work factor in tests. At the production factor (12),
+# bcrypt costs ~380ms per hash/verify and dominates the suite runtime; at 4 it
+# is ~1.6ms. The cost is encoded in the hash, so test-created hashes are also
+# cheap to verify. Production reads no BCRYPT_ROUNDS and defaults to 12.
+os.environ["BCRYPT_ROUNDS"] = "4"
 
 # ruff: noqa: E402 - Must set env vars before imports
 from datetime import date, datetime, timedelta, timezone
@@ -79,6 +88,7 @@ def set_test_environment():
     os.environ["DATABASE_URL"] = TEST_DATABASE_URL
     os.environ["DEBUG"] = "false"
     os.environ["LOG_LEVEL"] = "ERROR"  # Reduce noise in test output
+    os.environ["BCRYPT_ROUNDS"] = "4"  # Fast hashing for tests (see module header)
     yield
     # Cleanup
     os.environ.pop("ENVIRONMENT", None)
@@ -150,8 +160,8 @@ def test_password() -> str:
 
 @pytest.fixture
 def password_hash(test_password: str) -> str:
-    """Hashed version of test password."""
-    return bcrypt.hashpw(test_password.encode(), bcrypt.gensalt()).decode()
+    """Hashed version of test password (work factor 4 — see module header)."""
+    return bcrypt.hashpw(test_password.encode(), bcrypt.gensalt(4)).decode()
 
 
 @pytest.fixture

--- a/tests/unit/test_profile_security.py
+++ b/tests/unit/test_profile_security.py
@@ -204,19 +204,21 @@ class TestHandlePasswordChange:
 
     @patch("routes.auth.profile_update.password.get_session")
     @patch("routes.auth.profile_update.password.log_security_event")
+    @patch("routes.auth.profile_update.password.bcrypt_gensalt")
     @patch("routes.auth.profile_update.password.bcrypt")
     @patch("routes.auth.profile_update.password.validate_password_strength")
     def test_updates_password_hash_in_database(
         self,
         mock_validate: Mock,
         mock_bcrypt: Mock,
+        mock_gensalt: Mock,
         mock_log: Mock,
         mock_get_session: Mock,
     ):
         """Test updates user's password hash in database."""
         mock_validate.return_value = (True, None)
         mock_bcrypt.checkpw.return_value = True
-        mock_bcrypt.gensalt.return_value = b"$2b$12$fakesalt"
+        mock_gensalt.return_value = b"$2b$04$fakesalt"
         new_hash = b"$2b$12$newhash"
         mock_bcrypt.hashpw.return_value = new_hash
 
@@ -236,4 +238,4 @@ class TestHandlePasswordChange:
         # Verify new hash was set
         assert mock_user.password_hash == new_hash.decode("utf-8")
         # Verify bcrypt was called with new password
-        mock_bcrypt.hashpw.assert_called_once_with(b"NewPass123!", mock_bcrypt.gensalt.return_value)
+        mock_bcrypt.hashpw.assert_called_once_with(b"NewPass123!", mock_gensalt.return_value)


### PR DESCRIPTION
The suite took 510s. Three root causes, all fixed:

1. bcrypt at the default work factor (12) costs ~380ms per hash/verify. Almost every test hashes a password and performs a login, so ~0.76s of bcrypt ran before each test even started. Added an env-configurable work factor via core/helpers/passwords.bcrypt_gensalt() — defaults to 12 (production unchanged), conftest sets BCRYPT_ROUNDS=4 (~1.6ms/op).

2. pytest.ini hardcoded --cov into addopts, so coverage instrumentation ran on every invocation. Moved coverage out of addopts; it is now opt-in (CI passes --cov explicitly; `run-tests --coverage` does too).

3. pytest-xdist was a declared dependency but never enabled. Added it to the nix dev env and enabled `-n auto`. Each xdist worker gets its own SQLite file (test_sabc_<worker>.db) for isolation.

Also removed the dead PostgreSQL setup from the run-tests script — tests use file-based SQLite (conftest overrides DATABASE_URL).

Result: plain run 510s -> ~39s; coverage run -> ~60s. 969 pass.