### PR TITLE
Fix: CSRF token empty on cookie-less first request (first-visit login 403)

### DIFF
--- a/app_setup.py
+++ b/app_setup.py
@@ -33,8 +33,15 @@ from core.security_middleware import SecurityHeadersMiddleware
 
 
 def get_csrf_token(request: Request) -> str:
-    """Extract CSRF token from request cookies."""
-    return request.cookies.get("csrf_token", "")
+    """Return the CSRF token to embed in a form's hidden field.
+
+    Normally this is the value of the csrf_token cookie. On a cookie-less
+    first request the cookie does not exist yet, so we fall back to the token
+    the CSRF middleware stashed on the request scope (see
+    core/csrf_middleware.py) — that same token is set as the cookie on the
+    response, so the rendered form and the cookie stay in agreement.
+    """
+    return request.cookies.get("csrf_token", "") or request.scope.get("sabc_csrf_token", "")
 
 
 _DEV_SECRET_FALLBACK_ENVS = {"development", "test"}

--- a/core/csrf_middleware.py
+++ b/core/csrf_middleware.py
@@ -1,16 +1,22 @@
 """Custom CSRF middleware that supports both headers and form data."""
 
 import functools
+import http.cookies
 import os
 from email import policy
 from email.message import EmailMessage
 from email.parser import BytesParser
 from typing import Optional
 
+from starlette.datastructures import MutableHeaders
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
-from starlette.types import Receive, Scope, Send
+from starlette.types import Message, Receive, Scope, Send
 from starlette_csrf.middleware import CSRFMiddleware as BaseCSRFMiddleware
+
+# ASGI scope key under which we stash a freshly generated CSRF token on a
+# cookie-less first request, so get_csrf_token() and send() agree on its value.
+_SCOPE_TOKEN_KEY = "sabc_csrf_token"
 
 # Cap the request body we'll drain into memory looking for the CSRF token.
 # nginx already enforces client_max_body_size 15m upstream; we leave a small
@@ -63,6 +69,17 @@ class CSRFMiddleware(BaseCSRFMiddleware):
 
         request = Request(scope, receive)
         csrf_cookie = request.cookies.get(self.cookie_name)
+
+        # First visit: no CSRF cookie exists yet. The base middleware only
+        # generates the cookie token at response time — too late for the
+        # template, which renders the form's hidden csrf_token field during
+        # request handling. Generate the token up front and stash it on the
+        # ASGI scope so get_csrf_token() can embed it in forms AND our send()
+        # below sets the *same* token as the cookie. Without this the form
+        # token is empty on a cookie-less first request and the first POST
+        # (e.g. login) fails CSRF validation with a 403.
+        if csrf_cookie is None:
+            scope[_SCOPE_TOKEN_KEY] = self._generate_csrf_token()
 
         # Check if CSRF validation is required
         should_validate = self._url_is_required(request.url) or (
@@ -150,3 +167,28 @@ class CSRFMiddleware(BaseCSRFMiddleware):
         # Continue processing with cached body if we read it
         send = functools.partial(self.send, send=send, scope=scope)
         await self.app(scope, receive, send)
+
+    async def send(self, message: Message, send: Send, scope: Scope) -> None:
+        """Set the CSRF cookie, reusing the token pre-generated in __call__.
+
+        The base implementation generates a fresh token here at response time;
+        on a cookie-less first request that token would not match the one
+        already rendered into the page's forms. We reuse the scope-stashed
+        token (see __call__) so the cookie and the form token agree.
+        """
+        if message["type"] == "http.response.start":
+            request = Request(scope)
+            if request.cookies.get(self.cookie_name) is None:
+                token = scope.get(_SCOPE_TOKEN_KEY) or self._generate_csrf_token()
+                cookie: http.cookies.BaseCookie = http.cookies.SimpleCookie()
+                cookie[self.cookie_name] = token
+                cookie[self.cookie_name]["path"] = self.cookie_path
+                cookie[self.cookie_name]["secure"] = self.cookie_secure
+                cookie[self.cookie_name]["httponly"] = self.cookie_httponly
+                cookie[self.cookie_name]["samesite"] = self.cookie_samesite
+                if self.cookie_domain is not None:  # pragma: no cover
+                    cookie[self.cookie_name]["domain"] = self.cookie_domain
+                message.setdefault("headers", [])
+                headers = MutableHeaders(scope=message)
+                headers.append("set-cookie", cookie.output(header="").strip())
+        await send(message)

--- a/tests/unit/test_csrf_middleware.py
+++ b/tests/unit/test_csrf_middleware.py
@@ -1,0 +1,88 @@
+"""Tests for the custom CSRF middleware.
+
+Regression coverage for the cookie-less-first-visit bug: the form's hidden
+csrf_token field used to render empty on a request that arrived without a
+csrf_token cookie (e.g. a first-ever GET /login), so the first POST failed
+CSRF validation with a 403.
+
+The app disables CSRF in the test environment, so these tests wire the
+middleware onto a minimal standalone app and exercise the real
+get_csrf_token() helper used by templates.
+"""
+
+import re
+
+from starlette.applications import Starlette
+from starlette.responses import HTMLResponse, PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from app_setup import get_csrf_token
+from core.csrf_middleware import CSRFMiddleware
+
+_FORM_TOKEN = re.compile(r'value="([^"]*)"')
+
+
+def _make_client() -> TestClient:
+    async def form_page(request):
+        # Mirrors how templates embed the token via the csrf_token() macro.
+        return HTMLResponse(f'<input name="csrf_token" value="{get_csrf_token(request)}">')
+
+    async def submit(request):
+        return PlainTextResponse("ok")
+
+    app = Starlette(
+        routes=[
+            Route("/form", form_page),
+            Route("/submit", submit, methods=["POST"]),
+        ]
+    )
+    app.add_middleware(
+        CSRFMiddleware,
+        secret="test-secret-key-for-csrf",
+        cookie_name="csrf_token",
+        header_name="x-csrf-token",
+    )
+    return TestClient(app)
+
+
+def test_form_token_populated_on_cookieless_first_visit():
+    """The form's csrf_token must be non-empty even with no prior cookie."""
+    client = _make_client()  # fresh client => no cookies sent on the first GET
+
+    response = client.get("/form")
+
+    match = _FORM_TOKEN.search(response.text)
+    assert match is not None
+    assert match.group(1), "form CSRF token is empty on a cookie-less first visit"
+
+
+def test_first_visit_response_cookie_matches_form_token():
+    """The cookie set on the first response must equal the rendered form token."""
+    client = _make_client()
+
+    response = client.get("/form")
+
+    form_token = _FORM_TOKEN.search(response.text).group(1)
+    assert client.cookies.get("csrf_token") == form_token
+
+
+def test_post_succeeds_immediately_after_first_visit():
+    """A GET then POST with the first-visit token must pass CSRF validation."""
+    client = _make_client()
+
+    form_token = _FORM_TOKEN.search(client.get("/form").text).group(1)
+    response = client.post("/submit", data={"csrf_token": form_token})
+
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+
+def test_post_without_token_is_rejected():
+    """A POST with no CSRF token is still rejected with a 403."""
+    client = _make_client()
+    client.get("/form")  # establish the cookie
+
+    response = client.post("/submit", data={})
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Problem

The login/register/forgot-password/reset-password/logout forms embed `get_csrf_token(request)`, which read the token directly from the request's `csrf_token` cookie:

```python
def get_csrf_token(request: Request) -> str:
    return request.cookies.get("csrf_token", "")
```

On a **first-ever request**, that cookie doesn't exist yet — the base `starlette-csrf` middleware only generates and sets it at *response* time, after the template has already rendered. So the form's hidden `csrf_token` field rendered **empty**, and a user whose first request was `GET /login` (direct link, fresh incognito window, bookmark) got a **403 "CSRF token verification failed"** on their first login POST. Reloading worked (the second request carried the cookie), so the bug was self-recovering but real.

Found while building a Playwright harness — a fresh browser context hitting `/login` reproduced it every time.

## Fix

When a request arrives with no CSRF cookie, the middleware now generates the token **up front** in `__call__` and stashes it on the ASGI scope. `send()` reuses that same token when setting the cookie, and `get_csrf_token()` falls back to it when the cookie is absent — so the rendered form token and the response cookie always agree.

- `core/csrf_middleware.py` — stash a generated token on the scope for cookie-less requests; override `send()` to set the cookie from that stashed token instead of generating a fresh, mismatched one.
- `app_setup.py` — `get_csrf_token()` falls back to the scope token when the cookie is absent.

## Tests

Adds `tests/unit/test_csrf_middleware.py`. The app disables CSRF in the test environment, so the tests wire the real middleware onto a standalone Starlette app and exercise the real `get_csrf_token` helper: form token non-empty on first visit, response cookie matches the form token, GET→POST succeeds immediately, and a token-less POST is still rejected with 403.

Full suite: 973 passed, 81% coverage. `format-code` / `check-code` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)