### PR TITLE
fix(ci): align pydantic_core pin with pydantic 2.13.4

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -43,7 +43,7 @@ psycopg2-binary==2.9.12
 py-cpuinfo==9.0.0
 pycparser==2.22
 pydantic==2.13.4
-pydantic_core==2.47.0
+pydantic_core==2.46.4
 pytest==9.1.0
 pytest-asyncio==1.4.0
 pytest-base-url==2.1.0


### PR DESCRIPTION
## Problem

CI failed with `ResolutionImpossible`:

```
The user requested pydantic_core==2.47.0
pydantic 2.13.4 depends on pydantic-core==2.46.4
```

## Root cause

A stray dependabot bump pushed `pydantic_core` to `2.47.0` in `requirements-ci.txt` without a matching `pydantic` bump. pydantic 2.13.4 hard-pins `pydantic-core==2.46.4`. `requirements.txt` and `requirements-test.txt` don't pin `pydantic_core`, so only the CI file was broken.

## Fix

Align the pin: `pydantic_core==2.47.0` → `pydantic_core==2.46.4`. Verified the resolution succeeds via a `pip install --dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)