### PR TITLE
fix(ci): stop pinning pydantic_core to prevent recurring CI conflict

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -43,7 +43,9 @@ psycopg2-binary==2.9.12
 py-cpuinfo==9.0.0
 pycparser==2.22
 pydantic==2.13.4
-pydantic_core==2.47.0
+# pydantic-core is intentionally NOT pinned here: pydantic exactly pins its
+# matching pydantic-core, and a standalone pin lets dependabot bump it out of
+# lockstep with pydantic, breaking resolution. Let it resolve transitively.
 pytest==9.1.1
 pytest-asyncio==1.4.0
 pytest-base-url==2.1.0


### PR DESCRIPTION
## Problem

CI keeps failing with `ResolutionImpossible` after dependabot bumps:

```
The user requested pydantic_core==2.47.0
pydantic 2.13.4 depends on pydantic-core==2.46.4
```

This has now broken master **twice** (#347 fixed it once, then PR #354's python-runtime bump reverted the pin straight back to 2.47.0).

## Root cause

`requirements-ci.txt` pins `pydantic_core` **standalone**, in addition to `pydantic`. Dependabot bumps that line to the latest pydantic-core (2.47.0) independently, but pydantic 2.13.4 hard-pins `pydantic-core==2.46.4`. Grouping doesn't help — pydantic has no newer release, so only pydantic_core moves out of lockstep.

## Fix

Remove the standalone `pydantic_core` pin from `requirements-ci.txt` and let it resolve transitively from pydantic — exactly what `requirements.txt` (prod) already does. Now the version is always in lockstep with pydantic, and dependabot has no standalone line to bump. Added a comment so it isn't re-added.

Verified with `pip install --dry-run -r requirements-ci.txt`: resolves cleanly to `pydantic-core==2.46.4`, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)