### PR TITLE
fix(polls): allow night/early-morning tournament poll times

### DIFF
--- a/routes/voting/vote_validation.py
+++ b/routes/voting/vote_validation.py
@@ -27,9 +27,9 @@ def validate_tournament_location_vote(vote_data: dict) -> Tuple[Optional[str], O
         if end_time <= start_time:
             return None, "End time must be after start time"
 
-        # Validate reasonable tournament hours (4 AM to 11 PM)
-        if start_time.hour < 4 or end_time.hour > 23:
-            return None, "Tournament times must be between 4:00 AM and 11:00 PM"
+        # Any hour of the day is allowed so night / early-morning tournaments
+        # (e.g. a 12:01 AM start) can be scheduled. The HH:MM parse above
+        # already constrains values to a valid 00:00-23:59 range.
 
     except ValueError:
         return None, "Invalid time format. Use HH:MM"

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -122,8 +122,10 @@
 </div></div>
 {% endmacro %}
 
-{# Time select options macro - generates time options for dropdowns #}
-{% macro time_select_options(start_hour=5, end_hour=20, interval_minutes=30, selected_time='') %}
+{# Time select options macro - generates time options for dropdowns.
+   Starts at midnight so night / early-morning tournaments are selectable, and
+   includes a dedicated 12:01 AM (00:01) start option immediately after 12:00 AM. #}
+{% macro time_select_options(start_hour=0, end_hour=20, interval_minutes=30, selected_time='') %}
 {% for hour in range(start_hour, end_hour + 1) %}
     {% for minute in [0, interval_minutes] if minute < 60 %}
         {% set time_24 = "%02d:%02d"|format(hour, minute) %}
@@ -132,6 +134,9 @@
         {% set ampm = 'AM' if hour < 12 else 'PM' %}
         {% set time_display = "%d:%02d %s"|format(hour_12, minute, ampm) %}
         <option value="{{ time_24 }}" {% if time_24 == selected_time %}selected{% endif %}>{{ time_display }}</option>
+        {% if hour == 0 and minute == 0 %}
+        <option value="00:01" {% if selected_time == '00:01' %}selected{% endif %}>12:01 AM</option>
+        {% endif %}
     {% endfor %}
 {% endfor %}
 {% endmacro %}

--- a/templates/polls.html
+++ b/templates/polls.html
@@ -194,44 +194,14 @@
                         <div class="col-6">
                           <select id="start_time_admin_own_{{ poll.id }}" class="form-select" required title="Start Time">
                             <option value="">Start...</option>
-                            <option value="05:00" selected>5:00 AM</option>
-                            <option value="05:30">5:30 AM</option>
-                            <option value="06:00">6:00 AM</option>
-                            <option value="06:30">6:30 AM</option>
-                            <option value="07:00">7:00 AM</option>
-                            <option value="07:30">7:30 AM</option>
-                            <option value="08:00">8:00 AM</option>
-                            <option value="08:30">8:30 AM</option>
-                            <option value="09:00">9:00 AM</option>
-                            <option value="09:30">9:30 AM</option>
-                            <option value="10:00">10:00 AM</option>
-                            <option value="10:30">10:30 AM</option>
-                            <option value="11:00">11:00 AM</option>
-                            <option value="11:30">11:30 AM</option>
-                            <option value="12:00">12:00 PM</option>
-                            <option value="12:30">12:30 PM</option>
-                            <option value="13:00">1:00 PM</option>
-                            <option value="13:30">1:30 PM</option>
-                            <option value="14:00">2:00 PM</option>
-                            <option value="14:30">2:30 PM</option>
-                            <option value="15:00">3:00 PM</option>
-                            <option value="15:30">3:30 PM</option>
-                            <option value="16:00">4:00 PM</option>
-                            <option value="16:30">4:30 PM</option>
-                            <option value="17:00">5:00 PM</option>
-                            <option value="17:30">5:30 PM</option>
-                            <option value="18:00">6:00 PM</option>
-                            <option value="18:30">6:30 PM</option>
-                            <option value="19:00">7:00 PM</option>
-                            <option value="19:30">7:30 PM</option>
-                            <option value="20:00">8:00 PM</option>
+{{ time_select_options(0, 20, 30, "05:00") }}
                           </select>
                           <div class="form-hint text-center mt-1">Start</div>
                         </div>
                         <div class="col-6">
                           <select id="end_time_admin_own_{{ poll.id }}" class="form-select" required title="End Time">
                             <option value="">End...</option>
-{{ time_select_options(5, 20, 30, "15:00") }}
+{{ time_select_options(0, 20, 30, "15:00") }}
                           </select>
                           <div class="form-hint text-center mt-1">End</div>
                         </div>
@@ -303,14 +273,14 @@
                         <div class="col-6">
                           <select id="admin_start_time_{{ poll.id }}" class="form-select" required title="Start Time">
                             <option value="">Start...</option>
-{{ time_select_options(5, 20, 30) }}
+{{ time_select_options(0, 20, 30) }}
                           </select>
                           <div class="form-hint text-center mt-1">Start</div>
                         </div>
                         <div class="col-6">
                           <select id="admin_end_time_{{ poll.id }}" class="form-select" required title="End Time">
                             <option value="">End...</option>
-{{ time_select_options(5, 20, 30, "15:00") }}
+{{ time_select_options(0, 20, 30, "15:00") }}
                             <option value="20:30">8:30 PM</option>
                             <option value="21:00">9:00 PM</option>
                             <option value="21:30">9:30 PM</option>
@@ -368,44 +338,14 @@
                       <div class="col-6">
                         <select id="start_time_nonadmin_{{ poll.id }}" class="form-select" required title="Start Time">
                           <option value="">Start...</option>
-                          <option value="05:00" selected>5:00 AM</option>
-                          <option value="05:30">5:30 AM</option>
-                          <option value="06:00">6:00 AM</option>
-                          <option value="06:30">6:30 AM</option>
-                          <option value="07:00">7:00 AM</option>
-                          <option value="07:30">7:30 AM</option>
-                          <option value="08:00">8:00 AM</option>
-                          <option value="08:30">8:30 AM</option>
-                          <option value="09:00">9:00 AM</option>
-                          <option value="09:30">9:30 AM</option>
-                          <option value="10:00">10:00 AM</option>
-                          <option value="10:30">10:30 AM</option>
-                          <option value="11:00">11:00 AM</option>
-                          <option value="11:30">11:30 AM</option>
-                          <option value="12:00">12:00 PM</option>
-                          <option value="12:30">12:30 PM</option>
-                          <option value="13:00">1:00 PM</option>
-                          <option value="13:30">1:30 PM</option>
-                          <option value="14:00">2:00 PM</option>
-                          <option value="14:30">2:30 PM</option>
-                          <option value="15:00">3:00 PM</option>
-                          <option value="15:30">3:30 PM</option>
-                          <option value="16:00">4:00 PM</option>
-                          <option value="16:30">4:30 PM</option>
-                          <option value="17:00">5:00 PM</option>
-                          <option value="17:30">5:30 PM</option>
-                          <option value="18:00">6:00 PM</option>
-                          <option value="18:30">6:30 PM</option>
-                          <option value="19:00">7:00 PM</option>
-                          <option value="19:30">7:30 PM</option>
-                          <option value="20:00">8:00 PM</option>
+{{ time_select_options(0, 20, 30, "05:00") }}
                         </select>
                         <div class="form-hint text-center mt-1">Start</div>
                       </div>
                       <div class="col-6">
                         <select id="end_time_nonadmin_{{ poll.id }}" class="form-select" required title="End Time">
                           <option value="">End...</option>
-{{ time_select_options(5, 20, 30, "15:00") }}
+{{ time_select_options(0, 20, 30, "15:00") }}
                           <option value="20:30">8:30 PM</option>
                           <option value="21:00">9:00 PM</option>
                           <option value="21:30">9:30 PM</option>

--- a/tests/integration/test_voting_workflows.py
+++ b/tests/integration/test_voting_workflows.py
@@ -70,8 +70,8 @@ class TestTournamentLocationValidation:
         assert error is not None
         assert "End time must be after start time" in error
 
-    def test_validate_unreasonable_hours(self, db_session: Session):
-        """Test validation with unreasonable tournament hours."""
+    def test_validate_night_tournament_hours(self, db_session: Session):
+        """Early-morning / night starts (e.g. 12:01 AM, 3:00 AM) are allowed."""
         lake = Lake(yaml_key="test", display_name="Test Lake")
         db_session.add(lake)
         db_session.commit()
@@ -80,17 +80,37 @@ class TestTournamentLocationValidation:
         db_session.add(ramp)
         db_session.commit()
 
-        # Start too early
+        for start_time in ("00:01", "01:00", "03:00", "04:00"):
+            vote_data = {
+                "lake_id": str(lake.id),
+                "ramp_id": str(ramp.id),
+                "start_time": start_time,
+                "end_time": "12:00",
+            }
+            option_text, error = validate_tournament_location_vote(vote_data)
+            assert error is None, f"{start_time} should be valid, got: {error}"
+            assert option_text is not None
+
+    def test_validate_rejects_end_before_start(self, db_session: Session):
+        """End time must still be after start time."""
+        lake = Lake(yaml_key="test", display_name="Test Lake")
+        db_session.add(lake)
+        db_session.commit()
+
+        ramp = Ramp(lake_id=lake.id, name="Test Ramp")
+        db_session.add(ramp)
+        db_session.commit()
+
         vote_data = {
             "lake_id": str(lake.id),
             "ramp_id": str(ramp.id),
-            "start_time": "03:00",
-            "end_time": "12:00",
+            "start_time": "12:00",
+            "end_time": "06:00",
         }
         option_text, error = validate_tournament_location_vote(vote_data)
         assert option_text is None
         assert error is not None
-        assert "between 4:00 AM and 11:00 PM" in error
+        assert "End time must be after start time" in error
 
     def test_validate_valid_tournament_location(self, db_session: Session):
         """Test validation with valid tournament location data."""


### PR DESCRIPTION
## Problem

When an admin sets up a tournament-location poll, the start-time / end-time selectors only offered hours starting at **5:00 AM**. This blocked the club from scheduling **night tournaments**, including a specific **12:01 AM start** that was requested. The hours 1:00, 2:00, 3:00, and 4:00 AM were missing entirely.

On the backend, `validate_tournament_location_vote` also rejected any start time before 4:00 AM ("Tournament times must be between 4:00 AM and 11:00 PM"), so even a manually submitted early start would have been refused.

## Fix

- **`templates/macros.html`** — `time_select_options` now defaults `start_hour` to `0` (midnight) and emits a dedicated `12:01 AM` (`00:01`) option immediately after `12:00 AM`. Value/label conventions are unchanged (`HH:MM` values, `h:MM AM/PM` labels).
- **`templates/polls.html`** — Replaced the two hardcoded 5-AM-onward start-time `<option>` lists (they duplicated the macro's output) with `time_select_options`, and switched every caller to `start_hour=0`. The default selection (5:00 AM start / 3:00 PM end) is preserved via the `selected_time` argument, so existing behavior is intact — early-morning hours are simply now available.
- **`routes/voting/vote_validation.py`** — Removed the `start_time.hour < 4` floor. Any hour is now allowed; the `%H:%M` parse still constrains values to `00:00-23:59` and end-must-be-after-start is still enforced.
- **`tests/integration/test_voting_workflows.py`** — Replaced the test that asserted a 3:00 AM start was rejected with one that verifies night starts (12:01/1/3/4 AM) are now accepted, plus a new test confirming end-before-start is still rejected.

## Checks

- `nix develop -c format-code` — pass
- `nix develop -c check-code` — pass (the 16 pre-existing MyPy errors in alembic migrations and `event_queries.py` are unrelated to this change; none of the modified files appear in the output)
- `nix develop -c run-tests` — pass (1045 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)