### PR TITLE
fix: default tournament entry fee $25 -> $50 per boat

### DIFF
--- a/alembic/versions/l9m0n1o2p3q4_update_default_entry_fee_to_50.py
+++ b/alembic/versions/l9m0n1o2p3q4_update_default_entry_fee_to_50.py
@@ -1,0 +1,56 @@
+"""Update default entry fee to 50
+
+Change the server-side default for events.entry_fee and tournaments.entry_fee
+from 25.00 to 50.00 ($50 per boat). Only affects the default for future rows;
+existing entry fees are left unchanged.
+
+Revision ID: l9m0n1o2p3q4
+Revises: k8l9m0n1o2p3
+Create Date: 2026-07-13 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "l9m0n1o2p3q4"
+down_revision: Union[str, None] = "k8l9m0n1o2p3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "events",
+        "entry_fee",
+        existing_type=sa.NUMERIC(),
+        server_default=sa.text("50.00"),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "tournaments",
+        "entry_fee",
+        existing_type=sa.NUMERIC(),
+        server_default=sa.text("50.00"),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "tournaments",
+        "entry_fee",
+        existing_type=sa.NUMERIC(),
+        server_default=sa.text("25.00"),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "events",
+        "entry_fee",
+        existing_type=sa.NUMERIC(),
+        server_default=sa.text("25.00"),
+        existing_nullable=True,
+    )

--- a/core/db_schema/models.py
+++ b/core/db_schema/models.py
@@ -88,7 +88,7 @@ class Event(Base):
     weigh_in_time: Mapped[Optional[time]] = mapped_column(Time)
     lake_name: Mapped[Optional[str]] = mapped_column(Text)
     ramp_name: Mapped[Optional[str]] = mapped_column(Text)
-    entry_fee: Mapped[Optional[Decimal]] = mapped_column(Numeric, default=25.00)
+    entry_fee: Mapped[Optional[Decimal]] = mapped_column(Numeric, default=50.00)
     is_cancelled: Mapped[Optional[bool]] = mapped_column(Boolean, default=False)
     holiday_name: Mapped[Optional[str]] = mapped_column(Text)
 
@@ -234,7 +234,7 @@ class Tournament(Base):
     start_time: Mapped[Optional[time]] = mapped_column(Time)
     end_time: Mapped[Optional[time]] = mapped_column(Time)
     fish_limit: Mapped[Optional[int]] = mapped_column(Integer, default=5)
-    entry_fee: Mapped[Optional[Decimal]] = mapped_column(Numeric, default=25.00)
+    entry_fee: Mapped[Optional[Decimal]] = mapped_column(Numeric, default=50.00)
     is_team: Mapped[Optional[bool]] = mapped_column(Boolean, default=True)
     is_paper: Mapped[Optional[bool]] = mapped_column(Boolean, default=False)
     big_bass_carryover: Mapped[Optional[Decimal]] = mapped_column(Numeric, default=0.0)


### PR DESCRIPTION
## Summary

Changes the DEFAULT tournament entry fee from **$25** to **$50 per boat**, matching the current club bylaws (which already state $50/boat with 100% payout).

The rest of the codebase (templates, admin form defaults, seed scripts, route form defaults, voting helpers) already used $50 — the two remaining $25 defaults lived in the SQLAlchemy model column defaults and the corresponding database `server_default`.

## Changes

- **`core/db_schema/models.py`**
  - `Event.entry_fee` column default: `25.00` -> `50.00`
  - `Tournament.entry_fee` column default: `25.00` -> `50.00`
- **`alembic/versions/l9m0n1o2p3q4_update_default_entry_fee_to_50.py`** (new migration, revision `l9m0n1o2p3q4`, down_revision `k8l9m0n1o2p3`)
  - Changes `server_default` on `events.entry_fee` and `tournaments.entry_fee` from `25.00` to `50.00`
  - `downgrade()` restores `25.00`

## Representation

Fee is stored in **dollars** (`Numeric`, e.g. `50.00`), not cents.

## Scope / safety

- Only the DEFAULT for future rows changes. Existing tournament/event entry fees are untouched.
- The unrelated `dues.amount` server_default of $25 (club dues, not entry fee) is intentionally left as-is.

## Verification

- `nix develop -c format-code` — passed (253 files unchanged, all checks passed)
- `nix develop -c check-code` — passed (only pre-existing baseline `alembic.op` mypy notices, present on every migration file)
- `nix develop -c run-tests` — 1044 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)