### PR TITLE
fix(ci): exclude templates from coverage to fix coverage 7.15 crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,12 @@ omit = [
     "env/*",
     "test_*.py",
     "*_test.py",
+    # Jinja2 compiles templates to code objects whose filename is the template
+    # path, so coverage traces them. They are not Python — coverage 7.15+ runs
+    # ast.parse() on reported files for its HTML report and crashes on template
+    # markup (INTERNALERROR: invalid syntax). Exclude templates from coverage.
+    "templates/*",
+    "*.html",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
## Problem

Dependabot PR #366 (python-runtime-minor group, which bumps `coverage` 7.14.3 → 7.15.1) fails CI. All 1044 tests pass, but the coverage **HTML-report** step crashes:

```
INTERNALERROR> File ".../coverage/phystokens.py", line 97, in find_soft_key_lines
INTERNALERROR>   for node in ast.walk(ast.parse(source)):
INTERNALERROR> File "<unknown>", line 57
INTERNALERROR>   <div><div class="fw-bold">100% Payback</div>...
INTERNALERROR> SyntaxError: invalid decimal literal
```

## Root cause

Jinja2 compiles templates to code objects whose `co_filename` is the template path, so coverage traces them as if they were source files. coverage **7.15+** now runs `ast.parse()` on every reported file (to detect soft keywords for syntax highlighting in the HTML report). Running `ast.parse()` on HTML markup (`templates/about.html:57`) raises `SyntaxError`, which surfaces as an `INTERNALERROR` and fails the job with exit code 3.

## Fix

Exclude templates from coverage measurement (`templates/*`, `*.html`). Templates are not Python and were **never counted** toward the coverage total (it stays 80.7%), so this changes no numbers and keeps the ≥70% gate satisfied — it just stops coverage from trying to parse markup as Python.

## Verification (local)

- `format-code` — pass
- `check-code` — MyPy: no issues in 246 files
- `run-tests` (CI-equivalent `--cov-report=html --cov-fail-under=70`) — **1044 passed, 1 skipped, coverage 80.73%**, HTML report written with no crash

Once merged, #366 will be rebased so it re-runs with 7.15.1 + this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)